### PR TITLE
network.cookie.leave-secure-alone

### DIFF
--- a/user.js
+++ b/user.js
@@ -1274,7 +1274,7 @@ user_pref("dom.storageManager.enabled", false);
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1213990 ***/
 user_pref("extensions.webextensions.keepStorageOnUninstall", false);
 user_pref("extensions.webextensions.keepUuidOnUninstall", false);
-/* 2708: prevent HTTP sites from setting cookies with the "secure" directive (default: true)
+/* 2708: prevent HTTP sites from setting cookies with the "secure" directive (default: true) (FF52+)
  * https://developer.mozilla.org/en-US/Firefox/Releases/52#HTTP ***/
 user_pref("network.cookie.leave-secure-alone", true);
 

--- a/user.js
+++ b/user.js
@@ -1274,6 +1274,9 @@ user_pref("dom.storageManager.enabled", false);
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1213990 ***/
 user_pref("extensions.webextensions.keepStorageOnUninstall", false);
 user_pref("extensions.webextensions.keepUuidOnUninstall", false);
+/* 2708: prevent HTTP sites from setting cookies with the "secure" directive (default: true)
+ * https://developer.mozilla.org/en-US/Firefox/Releases/52#HTTP ***/
+user_pref("network.cookie.leave-secure-alone", true);
 
 /*** 2800: SHUTDOWN [SETUP] ***/
 user_pref("ghacks_user.js.parrot", "2800 syntax error: the parrot's bleedin' demised!");


### PR DESCRIPTION
Idk if we need/want to add this since it's default true and unlikely ever gonna change.
We have others like this and pyllyukko has tons of those, ie enforcing the default value.
IMO we should add it but I'm open for discussion.