### PR TITLE
0001: extra info re starting in PB mode

### DIFF
--- a/user.js
+++ b/user.js
@@ -39,6 +39,7 @@ user_pref("ghacks_user.js.parrot", "Oh yes, the Norwegian Blue... what's wrong w
 
 /* 0001: Start Firefox in PB (Private Browsing) mode
  * [SETTING] Options>Privacy>History>Custom Settings>Always use private browsing mode
+ * [NOTE] In this mode, *all* windows are "private windows" and the PB mode icon is not displayed
  * [1] https://wiki.mozilla.org/Private_Browsing ***/
    // user_pref("browser.privatebrowsing.autostart", true);
 

--- a/user.js
+++ b/user.js
@@ -39,7 +39,7 @@ user_pref("ghacks_user.js.parrot", "Oh yes, the Norwegian Blue... what's wrong w
 
 /* 0001: Start Firefox in PB (Private Browsing) mode
  * [SETTING] Options>Privacy>History>Custom Settings>Always use private browsing mode
- * [NOTE] In this mode, *all* windows are "private windows" and the PB mode icon is not displayed
+ * [NOTE] In this mode *all* windows are "private windows" and the PB mode icon is not displayed
  * [1] https://wiki.mozilla.org/Private_Browsing ***/
    // user_pref("browser.privatebrowsing.autostart", true);
 


### PR DESCRIPTION
Because PB mode still allows the key-commands/menus/context menus/buttons to do both "new window" and "new private window", and because in this mode the PB mode purple mask icon is never shown, this is not clear. See issue #73