### PR TITLE
extensions.blocklist.url

### DIFF
--- a/user.js
+++ b/user.js
@@ -237,7 +237,7 @@ user_pref("ghacks_user.js.parrot", "0400 syntax error: the parrot's passed on!")
  * [1] https://blog.mozilla.org/security/2015/03/03/revoking-intermediate-certificates-introducing-onecrl
  * [2] https://trac.torproject.org/projects/tor/ticket/16931 ***/
 user_pref("extensions.blocklist.enabled", true);
-user_pref("extensions.blocklist.url", "https://blocklist.addons.mozilla.org/blocklist/3/%APP_ID%/%APP_VERSION%/");
+user_pref("extensions.blocklist.url", "https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%APP_ID%/%APP_VERSION%/");
 /* 0402: enable Kinto blocklist updates (FF50+)
  * What is Kinto?: https://wiki.mozilla.org/Firefox/Kinto#Specifications
  * As Firefox transitions to Kinto, the blocklists have been broken down into entries for certs to be


### PR DESCRIPTION
https://blocklist.addons.mozilla.org/blocklist/3/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/53.0.3/
... already redirects to ...
https://blocklists.settings.services.mozilla.com/v1/blocklist/3/%7Bec8030f7-c20a-464f-9b0e-13a3a9e97384%7D/53.0.3/
... in FF53.0.3 so we can already commit this FF54 change that uses the direct URL

https://github.com/ghacksuserjs/ghacks-user.js/issues/87#issuecomment-296562854