### PR TITLE
1840 - add override url + disable local fallback

### DIFF
--- a/user.js
+++ b/user.js
@@ -957,7 +957,7 @@ user_pref("browser.eme.ui.enabled", false); // hides "Play DRM Content" checkbox
 user_pref("media.gmp-gmpopenh264.enabled", false); // (hidden pref)
 user_pref("media.gmp-gmpopenh264.autoupdate", false);
 user_pref("media.gmp-manager.url", "data:text/plain,");
-user_pref("media.gmp-manager.url.override", "data:,"); // (hidden pref)
+user_pref("media.gmp-manager.url.override", "data:text/plain,"); // (hidden pref)
 user_pref("media.gmp-manager.updateEnabled", false); // disable local fallback (hidden pref)
 
 /*** 2000: MEDIA / CAMERA / MIC ***/

--- a/user.js
+++ b/user.js
@@ -957,8 +957,8 @@ user_pref("browser.eme.ui.enabled", false); // hides "Play DRM Content" checkbox
 user_pref("media.gmp-gmpopenh264.enabled", false); // (hidden pref)
 user_pref("media.gmp-gmpopenh264.autoupdate", false);
 user_pref("media.gmp-manager.url", "data:text/plain,");
-user_pref("media.gmp-manager.url.override", "data:,");
-user_pref("media.gmp-manager.updateEnabled", false); // disable local fallback
+user_pref("media.gmp-manager.url.override", "data:,"); // (hidden pref)
+user_pref("media.gmp-manager.updateEnabled", false); // disable local fallback (hidden pref)
 
 /*** 2000: MEDIA / CAMERA / MIC ***/
 user_pref("ghacks_user.js.parrot", "2000 syntax error: the parrot's snuffed it!");

--- a/user.js
+++ b/user.js
@@ -957,6 +957,8 @@ user_pref("browser.eme.ui.enabled", false); // hides "Play DRM Content" checkbox
 user_pref("media.gmp-gmpopenh264.enabled", false); // (hidden pref)
 user_pref("media.gmp-gmpopenh264.autoupdate", false);
 user_pref("media.gmp-manager.url", "data:text/plain,");
+user_pref("media.gmp-manager.url.override", "data:,");
+user_pref("media.gmp-manager.updateEnabled", false); // disable local fallback
 
 /*** 2000: MEDIA / CAMERA / MIC ***/
 user_pref("ghacks_user.js.parrot", "2000 syntax error: the parrot's snuffed it!");


### PR DESCRIPTION
they are both in TBB 7.0.2.
With .url.override set, media.gmp-manager.url is never used (but let's keep it anyway)
source: https://dxr.mozilla.org/mozilla-central/source/toolkit/modules/GMPInstallManager.jsm#66

Since ESR52 it is not enough anymore to block pinging the GMP update/download server.
There is a local fallback that must be blocked now as well. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1267495.