### PR TITLE
3009 - remove it

### DIFF
--- a/user.js
+++ b/user.js
@@ -1641,9 +1641,6 @@ user_pref("browser.backspace_action", 2);
  * 1=current window, 2=new window, 3=most recent window
  * [SETTING] Options>General>Tabs>Open new windows in a new tab instead ***/
 user_pref("browser.link.open_newwindow", 3);
-/* 3009: enable APZ (Async Pan/Zoom) - requires e10s
- * [1] https://www.ghacks.net/2015/07/28/scrolling-in-firefox-to-get-a-lot-better-thanks-to-apz/ ***/
-   // user_pref("layers.async-pan-zoom.enabled", true);
 /* 3010: enable ctrl-tab previews ***/
 user_pref("browser.ctrlTab.previews", true);
 /* 3011: don't open "page/selection source" in a tab. The window used instead is cleaner


### PR DESCRIPTION
the default value in 54 is true. It's not in my OS diff for 54 either so it's true on Linux and Mac as well. I don't think anyone would want to disable this anyway, and we have it as "enable APZ". The linked ghacks article is from 2 years ago and the pref was added before the move to github (no commits for it).
It's old, unnecessary and only wasting space, let's remove it.