### PR TITLE
Updater for Windows v3.0 (the real deal)

### DIFF
--- a/updater.bat
+++ b/updater.bat
@@ -3,7 +3,7 @@ TITLE ghacks user.js updater
 
 REM ### ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 3.0-alpha92
+REM ## version: 3.0
 
 SET _myname=%~n0
 SET _myparams=%*
@@ -59,7 +59,6 @@ IF DEFINED _updateb (
 		EXIT /B
 	)
 )
-GOTO begin
 :begin
 SET /A "_line=0"
 IF NOT EXIST user.js (
@@ -231,7 +230,5 @@ FOR /F "tokens=1,* delims=]" %%G IN ('find /n /v "" ^< "%~1"') DO (
 )
 ENDLOCAL
 DEL /F %~1 temp123 >nul
-GOTO EOF
+GOTO :EOF
 REM ############################
-
-:EOF

--- a/updater.bat
+++ b/updater.bat
@@ -65,7 +65,7 @@ DEL /F %2 2>nul
 FOR /F "tokens=* delims=" %%G IN (%1) DO (
 	SET _pref=%%G
 	SET "_temp=!_pref: =!"
-	IF /I "user.js.parrot"=="!_temp:user.js.parrot=!"
+	IF /I "!_temp!"=="!_temp:user.js.parrot=!" (
 		IF /I "user"=="!_temp:~0,4!" (
 			FOR /F "delims=," %%S IN ("!_pref!") DO (
 				SET _pref=%%S

--- a/updater.bat
+++ b/updater.bat
@@ -3,7 +3,7 @@ TITLE ghacks user.js updater
 
 REM ### ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 2.2
+REM ## version: 3.0
 
 SET _myname=%~n0
 SET _myparams=%*
@@ -18,13 +18,46 @@ IF /I "%~1"=="-unattended" (
 IF /I "%~1"=="-log" (
 	SET _log=1
 )
+IF /I "%~1"=="-logp" (
+	SET _log=1
+	SET _logp=1
+)
 IF /I "%~1"=="-multioverrides" (
 	SET _multi=1
+)
+IF /I "%~1"=="-merge" (
+	SET _merge=1
+)
+IF /I "%~1"=="-updatebatch" (
+	SET _updateb=1
 )
 SHIFT
 GOTO parse
 :endparse
 ECHO.
+IF DEFINED _updateb (
+	ECHO Checking updater version...
+	ECHO.
+	IF EXIST "!_myname!-updated.bat" (
+		DEL /F "!_myname!-updated.bat"
+	)
+	powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat', '!_myname!-updated.bat')" >nul
+	IF EXIST "!_myname!-updated.bat" (
+		CLS
+		SET "_myparams=!_myparams:-updatebatch=!"
+		SET "_myparams=!_myparams:-Updatebatch=!"
+		SET "_myparams=!_myparams:-UpdateBatch=!"
+		SET "_myparams=!_myparams:-UPDATEBATCH=!"
+		START CMD /C "!_myname!-updated.bat" !_myparams!
+		DEL /F "!_myname!.bat" >nul 2>&1
+		EXIT /B
+	) ELSE (
+		ECHO Failed. Make sure PowerShell is allowed internet access.
+		ECHO.
+		PAUSE
+		GOTO end
+	)
+)
 SET /A "_line=0"
 IF NOT EXIST user.js (
 	ECHO user.js not detected in the current directory.
@@ -47,7 +80,8 @@ IF NOT EXIST user.js (
 	:exitloop
 	IF !_line! GEQ 4 (
 		IF /I NOT "!_name!"=="!_name:ghacks=X!" (
-			ECHO ghacks user.js !_version:~2!,!_date!
+			SET _version=!_version:*version=version!
+			ECHO ghacks user.js !_version!,!_date!
 		) ELSE (
 			ECHO Current user.js version not recognised.
 		)
@@ -96,8 +130,77 @@ IF EXIST user.js (
 		IF %ERRORLEVEL% EQU 0 (
 			IF DEFINED _merge (
 				ECHO.
-				ECHO Merging not supported yet...
+				ECHO Merging...
 				ECHO.
+				IF EXIST user-overrides-merged.js (
+					DEL /F user-overrides-merged.js
+				)
+				IF EXIST temp2 (
+					DEL /F temp2
+				)
+				IF EXIST temp3 (
+					DEL /F temp3
+				)
+				COPY /B /V /Y user.js-overrides\*.js user-overrides
+				FOR /F "tokens=* delims=" %%G IN (user-overrides) DO (
+					SET _pref=%%G
+					SET "_temp=!_pref: =!"
+					IF /I "user"=="!_temp:~0,4!" (
+						FOR /F "delims=," %%S IN ("!_pref!") DO (
+							SET _pref=%%S
+						)
+						SET _pref=!_pref:"=""!
+						FIND /I "!_pref!" user-overrides-merged.js >nul 2>&1
+						IF ERRORLEVEL 1 (
+							FIND /I "!_pref!" user-overrides >temp1
+							FOR /F "tokens=* delims=" %%X IN (temp1) DO (
+								SET _temp=%%X
+								SET "_temp=!_temp: =!"
+								IF /I "user"=="!_temp:~0,4!" (
+									SET _pref=%%X
+								)
+							)
+							ECHO !_pref!>>user-overrides-merged.js
+						)
+					) ELSE (
+						ECHO !_pref!>>user-overrides-merged.js
+					)
+				)
+				COPY /B /V /Y user.js+user-overrides-merged.js temp2
+				FOR /F "tokens=* delims=" %%G IN (temp2) DO (
+					SET _pref=%%G
+					SET "_temp=!_pref: =!"
+					IF /I "user"=="!_temp:~0,4!" (
+						FOR /F "delims=," %%S IN ("!_pref!") DO (
+							SET _pref=%%S
+						)
+						SET _pref=!_pref:"=""!
+						FIND /I "!_pref!" temp3 >nul 2>&1
+						IF ERRORLEVEL 1 (
+							FIND /I "!_pref!" temp2 >temp1
+							FOR /F "tokens=* delims=" %%X IN (temp1) DO (
+								SET _temp=%%X
+								SET "_temp=!_temp: =!"
+								IF /I "user"=="!_temp:~0,4!" (
+									SET _pref=%%X
+								)
+							)
+							ECHO !_pref!>>temp3
+						)
+					) ELSE (
+						ECHO !_pref!>>temp3
+					)
+				)
+				IF EXIST user.js (
+					DEL /F user.js
+				)
+				IF EXIST temp2 (
+					DEL /F temp2
+				)
+				REN temp3 user.js
+				IF EXIST temp1 (
+					DEL /F temp1
+				)
 			) ELSE (
 				ECHO.
 				ECHO Appending...
@@ -109,7 +212,48 @@ IF EXIST user.js (
 	) ELSE (
 		IF EXIST "user-overrides.js" (
 			IF DEFINED _merge (
-				ECHO Merging user-overrides.js not supported yet...
+				ECHO Merging user-overrides.js...
+				IF EXIST temp2 (
+					DEL /F temp2
+				)
+				IF EXIST temp3 (
+					DEL /F temp3
+				)
+				COPY /B /V /Y user.js+user-overrides.js temp2
+				FOR /F "tokens=* delims=" %%G IN (temp2) DO (
+					SET _pref=%%G
+					SET "_temp=!_pref: =!"
+					IF /I "user"=="!_temp:~0,4!" (
+						FOR /F "delims=," %%S IN ("!_pref!") DO (
+							SET _pref=%%S
+						)
+						SET _pref=!_pref:"=""!
+						FIND /I "!_pref!" temp3 >nul 2>&1
+						IF ERRORLEVEL 1 (
+							FIND /I "!_pref!" temp2 >temp1
+							FOR /F "tokens=* delims=" %%X IN (temp1) DO (
+								SET _temp=%%X
+								SET "_temp=!_temp: =!"
+								IF /I "user"=="!_temp:~0,4!" (
+									SET _pref=%%X
+								)
+							)
+							ECHO !_pref!>>temp3
+						)
+					) ELSE (
+						ECHO !_pref!>>temp3
+					)
+				)
+				IF EXIST user.js (
+					DEL /F user.js
+				)
+				REN temp3 user.js
+				IF EXIST temp1 (
+					DEL /F temp1
+				)
+				IF EXIST temp2 (
+					DEL /F temp2
+				)
 			) ELSE (
 				ECHO Appending user-overrides.js...
 				ECHO.
@@ -159,3 +303,10 @@ IF NOT DEFINED _log (
 	IF NOT DEFINED _ua PAUSE
 )
 :end
+IF DEFINED _logp (
+	START user.js-update-log.txt
+)
+IF NOT "!_myname!"=="!_myname:-updated=X!" (
+	REN "!_myname!.bat" "!_myname:-updated=!.bat"
+	EXIT /B
+)

--- a/updater.bat
+++ b/updater.bat
@@ -182,7 +182,6 @@ IF EXIST user.js (
 		IF EXIST "user-overrides.js" (
 			IF DEFINED _merge (
 				ECHO Merging user-overrides.js...
-				DEL /F user.js temp2 2>nul
 				COPY /B /V /Y user.js+user-overrides.js temp2
 				CALL :merge temp2 user.js
 			) ELSE (

--- a/updater.bat
+++ b/updater.bat
@@ -42,10 +42,6 @@ IF DEFINED _updateb (
 	powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat', '!_myname!-updated.bat')" >nul
 	IF EXIST "!_myname!-updated.bat" (
 		CLS
-		SET "_myparams=!_myparams:-updatebatch=!"
-		SET "_myparams=!_myparams:-Updatebatch=!"
-		SET "_myparams=!_myparams:-UpdateBatch=!"
-		SET "_myparams=!_myparams:-UPDATEBATCH=!"
 		START CMD /C "!_myname!-updated.bat" !_myparams!
 		DEL /F "!_myname!.bat" >nul 2>&1
 		EXIT /B
@@ -115,8 +111,7 @@ IF NOT EXIST user.js (
 	:exitloop
 	IF !_line! GEQ 4 (
 		IF /I NOT "!_name!"=="!_name:ghacks=X!" (
-			SET _version=!_version:*version=version!
-			ECHO ghacks user.js !_version!,!_date!
+			ECHO ghacks user.js !_version:*version=version!,!_date!
 		) ELSE (
 			ECHO Current user.js version not recognised.
 		)

--- a/updater.bat
+++ b/updater.bat
@@ -53,7 +53,7 @@ IF DEFINED _updateb (
 	)
 ) ELSE (
 	IF NOT "!_myname!"=="!_myname:-updated=X!" (
-		CALL :renameafterImdone
+		CALL :begin
 		REN "!_myname!.bat" "!_myname:-updated=!.bat"
 		EXIT /B
 	)
@@ -87,7 +87,6 @@ FOR /F "tokens=* delims=" %%G IN (%1) DO (
 )
 EXIT /B
 REM ######
-:renameafterImdone
 :begin
 SET /A "_line=0"
 IF NOT EXIST user.js (

--- a/updater.bat
+++ b/updater.bat
@@ -62,37 +62,37 @@ IF DEFINED _updateb (
 		EXIT /B
 	)
 )
-REM -------------- Merge function ----------------------------
+GOTO begin
+REM ###### Merge function ######
 :merge
-IF "%4"=="GO" (
-	FOR /F "tokens=* delims=" %%G IN (%1) DO (
-		SET _pref=%%G
-		SET "_temp=!_pref: =!"
-		IF /I "user"=="!_temp:~0,4!" (
-			FOR /F "delims=," %%S IN ("!_pref!") DO (
-				SET _pref=%%S
-			)
-			SET _pref=!_pref:"=""!
-			FIND /I "!_pref!" %2 >nul 2>&1
-			IF ERRORLEVEL 1 (
-				FIND /I "!_pref!" %1 >%3
-				FOR /F "tokens=* delims=" %%X IN (%3) DO (
-					SET _temp=%%X
-					SET "_temp=!_temp: =!"
-					IF /I "user"=="!_temp:~0,4!" (
-						SET _pref=%%X
-					)
+FOR /F "tokens=* delims=" %%G IN (%1) DO (
+	SET _pref=%%G
+	SET "_temp=!_pref: =!"
+	IF /I "user"=="!_temp:~0,4!" (
+		FOR /F "delims=," %%S IN ("!_pref!") DO (
+			SET _pref=%%S
+		)
+		SET _pref=!_pref:"=""!
+		FIND /I "!_pref!" %2 >nul 2>&1
+		IF ERRORLEVEL 1 (
+			FIND /I "!_pref!" %1 >%3
+			FOR /F "tokens=* delims=" %%X IN (%3) DO (
+				SET _temp=%%X
+				SET "_temp=!_temp: =!"
+				IF /I "user"=="!_temp:~0,4!" (
+					SET _pref=%%X
 				)
-				ECHO !_pref!>>%2
 			)
-		) ELSE (
 			ECHO !_pref!>>%2
 		)
+	) ELSE (
+		ECHO !_pref!>>%2
 	)
-	EXIT /B
 )
-REM --------------------------------------------------------
+EXIT /B
+REM ######
 :renameafterImdone
+:begin
 SET /A "_line=0"
 IF NOT EXIST user.js (
 	ECHO user.js not detected in the current directory.
@@ -172,10 +172,10 @@ IF EXIST user.js (
 				DEL /F temp3 >nul 2>&1
 				DEL /F user-overrides-merged.js >nul 2>&1
 				COPY /B /V /Y user.js-overrides\*.js user-overrides
-				CALL :merge user-overrides user-overrides-merged.js temp1 GO
+				CALL :merge user-overrides user-overrides-merged.js temp1
 				COPY /B /V /Y user.js+user-overrides-merged.js temp2
 				DEL /F user.js >nul 2>&1
-				CALL :merge temp2 user.js temp1 GO
+				CALL :merge temp2 user.js temp1
 				DEL /F temp2 >nul 2>&1
 				DEL /F temp1 >nul 2>&1
 				REN temp3 user.js
@@ -194,7 +194,7 @@ IF EXIST user.js (
 				DEL /F temp2 >nul 2>&1
 				DEL /F user.js >nul 2>&1
 				COPY /B /V /Y user.js+user-overrides.js temp2
-				CALL :merge temp2 user.js temp1 GO
+				CALL :merge temp2 user.js temp1
 				DEL /F temp1 >nul 2>&1
 				DEL /F temp2 >nul 2>&1
 			) ELSE (

--- a/updater.bat
+++ b/updater.bat
@@ -49,7 +49,7 @@ IF DEFINED _updateb (
 		ECHO Failed. Make sure PowerShell is allowed internet access.
 		ECHO.
 		PAUSE
-		GOTO end
+		EXIT /B
 	)
 ) ELSE (
 	IF NOT "!_myname!"=="!_myname:-updated=X!" (
@@ -128,7 +128,7 @@ IF NOT DEFINED _ua (
 	REM ECHO.
 	CHOICE /M "Continue"
 	IF ERRORLEVEL 2 (
-		GOTO end
+		EXIT /B
 	)
 )
 CLS
@@ -136,7 +136,7 @@ ECHO.
 IF DEFINED _log (
 	CALL :log >>user.js-update-log.txt 2>&1
 	IF DEFINED _logp (
-		"user.js-update-log.txt"
+		START user.js-update-log.txt
 	)
 	EXIT /B
 	:log
@@ -227,4 +227,3 @@ IF EXIST user.js (
 IF NOT DEFINED _log (
 	IF NOT DEFINED _ua PAUSE
 )
-:end

--- a/updater.bat
+++ b/updater.bat
@@ -28,7 +28,7 @@ IF /I "%~1"=="-multioverrides" (
 IF /I "%~1"=="-merge" (
 	SET _merge=1
 )
-IF /I "%~1"=="-updatebatch" (
+IF "%~1"=="-updatebatch" (
 	SET _updateb=1
 )
 SHIFT
@@ -38,12 +38,12 @@ ECHO.
 IF DEFINED _updateb (
 	ECHO Checking updater version...
 	ECHO.
-	DEL /F "!_myname!-updated.bat" >nul 2>&1
+	DEL /F "!_myname!-updated.bat" 2>nul
 	powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat', '!_myname!-updated.bat')" >nul
 	IF EXIST "!_myname!-updated.bat" (
 		CLS
 		START CMD /C "!_myname!-updated.bat" !_myparams!
-		DEL /F "!_myname!.bat" >nul 2>&1
+		DEL /F "!_myname!.bat" 2>nul
 		EXIT /B
 	) ELSE (
 		ECHO Failed. Make sure PowerShell is allowed internet access.
@@ -71,8 +71,8 @@ FOR /F "tokens=* delims=" %%G IN (%1) DO (
 		SET _pref=!_pref:"=""!
 		FIND /I "!_pref!" %2 >nul 2>&1
 		IF ERRORLEVEL 1 (
-			FIND /I "!_pref!" %1 >%3
-			FOR /F "tokens=* delims=" %%X IN (%3) DO (
+			FIND /I "!_pref!" %1 >temp1
+			FOR /F "tokens=* delims=" %%X IN (temp1) DO (
 				SET _temp=%%X
 				SET "_temp=!_temp: =!"
 				IF /I "user"=="!_temp:~0,4!" (
@@ -85,8 +85,9 @@ FOR /F "tokens=* delims=" %%G IN (%1) DO (
 		ECHO !_pref!>>%2
 	)
 )
+DEL /F %1 temp1 2>nul
 EXIT /B
-REM ######
+REM ############################
 :begin
 SET /A "_line=0"
 IF NOT EXIST user.js (
@@ -162,16 +163,12 @@ IF EXIST user.js (
 				ECHO.
 				ECHO Merging...
 				ECHO.
-				DEL /F temp2 >nul 2>&1
-				DEL /F temp3 >nul 2>&1
-				DEL /F user-overrides-merged.js >nul 2>&1
+				DEL /F user-overrides-merged.js temp2 temp3 2>nul
 				COPY /B /V /Y user.js-overrides\*.js user-overrides
-				CALL :merge user-overrides user-overrides-merged.js temp1
+				CALL :merge user-overrides user-overrides-merged.js
 				COPY /B /V /Y user.js+user-overrides-merged.js temp2
-				DEL /F user.js >nul 2>&1
-				CALL :merge temp2 user.js temp1
-				DEL /F temp2 >nul 2>&1
-				DEL /F temp1 >nul 2>&1
+				DEL /F user.js 2>nul
+				CALL :merge temp2 user.js
 				REN temp3 user.js
 			) ELSE (
 				ECHO.
@@ -185,12 +182,9 @@ IF EXIST user.js (
 		IF EXIST "user-overrides.js" (
 			IF DEFINED _merge (
 				ECHO Merging user-overrides.js...
-				DEL /F temp2 >nul 2>&1
-				DEL /F user.js >nul 2>&1
+				DEL /F user.js temp2 2>nul
 				COPY /B /V /Y user.js+user-overrides.js temp2
-				CALL :merge temp2 user.js temp1
-				DEL /F temp1 >nul 2>&1
-				DEL /F temp2 >nul 2>&1
+				CALL :merge temp2 user.js
 			) ELSE (
 				ECHO Appending user-overrides.js...
 				ECHO.
@@ -209,7 +203,7 @@ IF EXIST user.js (
 	ECHO.
 	ECHO.
 	IF "!changed!"=="true" (
-		DEL /F user.js.old.bak >nul 2>&1
+		DEL /F user.js.old.bak 2>nul
 		ECHO Update complete.
 	) ELSE (
 		IF "!changed!"=="false" (

--- a/updater.bat
+++ b/updater.bat
@@ -3,7 +3,7 @@ TITLE ghacks user.js updater
 
 REM ### ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 3.0
+REM ## version: 3.0-alpha92
 
 SET _myname=%~n0
 SET _myparams=%*
@@ -28,6 +28,7 @@ IF /I "%~1"=="-multioverrides" (
 IF /I "%~1"=="-merge" (
 	SET _merge=1
 )
+REM case-sensitive check because we need to strip it from params
 IF "%~1"=="-updatebatch" (
 	SET _updateb=1
 )
@@ -35,65 +36,6 @@ SHIFT
 GOTO parse
 :endparse
 ECHO.
-IF DEFINED _updateb (
-	ECHO Checking updater version...
-	ECHO.
-	DEL /F "!_myname!-updated.bat" 2>nul
-	powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat', '!_myname!-updated.bat')" >nul
-	IF EXIST "!_myname!-updated.bat" (
-		CLS
-		START CMD /C "!_myname!-updated.bat" !_myparams!
-		DEL /F "!_myname!.bat" 2>nul
-		EXIT /B
-	) ELSE (
-		ECHO Failed. Make sure PowerShell is allowed internet access.
-		ECHO.
-		PAUSE
-		EXIT /B
-	)
-) ELSE (
-	IF NOT "!_myname!"=="!_myname:-updated=X!" (
-		CALL :begin
-		REN "!_myname!.bat" "!_myname:-updated=!.bat"
-		EXIT /B
-	)
-)
-GOTO begin
-REM ###### Merge function ######
-:merge
-DEL /F %2 2>nul
-FOR /F "tokens=* delims=" %%G IN (%1) DO (
-	SET _pref=%%G
-	SET "_temp=!_pref: =!"
-	IF /I "!_temp!"=="!_temp:user.js.parrot=!" (
-		IF /I "user"=="!_temp:~0,4!" (
-			FOR /F "delims=," %%S IN ("!_pref!") DO (
-				SET _pref=%%S
-			)
-			SET _pref=!_pref:"=""!
-			FIND /I "!_pref!" %2 >nul 2>&1
-			IF ERRORLEVEL 1 (
-				FIND /I "!_pref!" %1 >temp1
-				FOR /F "tokens=* delims=" %%X IN (temp1) DO (
-					SET _temp=%%X
-					SET "_temp=!_temp: =!"
-					IF /I "user"=="!_temp:~0,4!" (
-						SET _pref=%%X
-					)
-				)
-				ECHO !_pref!>>%2
-			)
-		) ELSE (
-			ECHO !_pref!>>%2
-		)
-	) ELSE (
-		ECHO !_pref!>>%2
-	)
-)
-DEL /F %1 temp1 2>nul
-EXIT /B
-REM ############################
-:begin
 SET /A "_line=0"
 IF NOT EXIST user.js (
 	ECHO user.js not detected in the current directory.
@@ -116,7 +58,7 @@ IF NOT EXIST user.js (
 	:exitloop
 	IF !_line! GEQ 4 (
 		IF /I NOT "!_name!"=="!_name:ghacks=X!" (
-			ECHO ghacks user.js !_version:*version=version!,!_date!
+			ECHO ghacks user.js !_version:~2!,!_date!
 		) ELSE (
 			ECHO Current user.js version not recognised.
 		)
@@ -132,9 +74,7 @@ IF NOT DEFINED _ua (
 	REM ECHO Visit the wiki for more detailed information.
 	REM ECHO.
 	CHOICE /M "Continue"
-	IF ERRORLEVEL 2 (
-		EXIT /B
-	)
+	IF ERRORLEVEL 2 EXIT /B
 )
 CLS
 ECHO.
@@ -151,7 +91,7 @@ IF DEFINED _log (
 	ECHO.
 )
 IF EXIST user.js (
-	REN user.js.bak user.js.old.bak >nul 2>&1
+	IF EXIST user.js.bak REN user.js.bak user.js.old.bak
 	REN user.js user.js.bak
 	ECHO Current user.js file backed up.
 	ECHO.
@@ -168,7 +108,6 @@ IF EXIST user.js (
 				ECHO.
 				ECHO Merging...
 				ECHO.
-				DEL /F user-overrides-merged.js temp2 2>nul
 				COPY /B /V /Y user.js-overrides\*.js user-overrides
 				CALL :merge user-overrides user-overrides-merged.js
 				COPY /B /V /Y user.js+user-overrides-merged.js temp2
@@ -205,12 +144,12 @@ IF EXIST user.js (
 	ECHO.
 	ECHO.
 	IF "!changed!"=="true" (
-		DEL /F user.js.old.bak 2>nul
+		IF EXIST user.js.old.bak DEL /F user.js.old.bak
 		ECHO Update complete.
 	) ELSE (
 		IF "!changed!"=="false" (
 			DEL /F user.js.bak
-			REN user.js.old.bak user.js.bak >nul 2>&1
+			IF EXIST user.js.old.bak REN user.js.old.bak user.js.bak
 			ECHO Update completed without changes.
 		) ELSE (
 			ECHO Update complete.
@@ -218,8 +157,8 @@ IF EXIST user.js (
 	)
 	ECHO.
 ) ELSE (
-	REN user.js.bak user.js >nul 2>&1
-	REN user.js.old.bak user.js.bak >nul 2>&1
+	IF EXIST user.js.bak REN user.js.bak user.js
+	IF EXIST user.js.old.bak REN user.js.old.bak user.js.bak
 	ECHO.
 	ECHO Update failed. Make sure PowerShell is allowed internet access.
 	ECHO.
@@ -229,3 +168,45 @@ IF EXIST user.js (
 IF NOT DEFINED _log (
 	IF NOT DEFINED _ua PAUSE
 )
+EXIT /B
+
+REM ###### Merge function ######
+:merge
+DEL /F %2 2>nul
+SETLOCAL disabledelayedexpansion
+FOR /F "tokens=1,* delims=]" %%G IN ('find /n /v "" ^< "%~1"') DO (
+	SET "_pref=%%H"
+	SETLOCAL enabledelayedexpansion
+	SET "_temp=!_pref: =!"
+	IF /I "user_pref"=="!_temp:~0,9!" (
+		IF /I NOT "user.js.parrot"=="!_temp:~12,14!" (
+			FOR /F "delims=," %%S IN ("!_pref!") DO (
+				SET "_pref=%%S"
+			)
+			SET _pref=!_pref:"=""!
+			FIND /I "!_pref!" %~2 >nul 2>&1
+			IF ERRORLEVEL 1 (
+				FIND /I "!_pref!" %~1 >temp123
+				FOR /F "tokens=* delims=" %%X IN (temp123) DO (
+					SET "_temp=%%X"
+					SET "_temp=!_temp: =!"
+					IF /I "user_pref"=="!_temp:~0,9!" (
+						SET "_pref=%%X"
+					)
+				)
+				ECHO(!_pref!>>%~2
+			)
+		) ELSE (
+			ECHO(!_pref!>>%~2
+		)
+	) ELSE (
+		ECHO(!_pref!>>%~2
+	)
+	ENDLOCAL
+)
+ENDLOCAL
+DEL /F %~1 temp123 >nul
+GOTO EOF
+REM ############################
+
+:EOF

--- a/updater.bat
+++ b/updater.bat
@@ -3,7 +3,7 @@ TITLE ghacks user.js updater
 
 REM ### ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 3.0-alpha92
+REM ## version: 3.0
 
 SET _myname=%~n0
 SET _myparams=%*
@@ -28,7 +28,6 @@ IF /I "%~1"=="-multioverrides" (
 IF /I "%~1"=="-merge" (
 	SET _merge=1
 )
-REM case-sensitive check because we need to strip it from params
 IF "%~1"=="-updatebatch" (
 	SET _updateb=1
 )
@@ -36,6 +35,65 @@ SHIFT
 GOTO parse
 :endparse
 ECHO.
+IF DEFINED _updateb (
+	ECHO Checking updater version...
+	ECHO.
+	DEL /F "!_myname!-updated.bat" 2>nul
+	powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat', '!_myname!-updated.bat')" >nul
+	IF EXIST "!_myname!-updated.bat" (
+		CLS
+		START CMD /C "!_myname!-updated.bat" !_myparams!
+		DEL /F "!_myname!.bat" 2>nul
+		EXIT /B
+	) ELSE (
+		ECHO Failed. Make sure PowerShell is allowed internet access.
+		ECHO.
+		PAUSE
+		EXIT /B
+	)
+) ELSE (
+	IF NOT "!_myname!"=="!_myname:-updated=X!" (
+		CALL :begin
+		REN "!_myname!.bat" "!_myname:-updated=!.bat"
+		EXIT /B
+	)
+)
+GOTO begin
+REM ###### Merge function ######
+:merge
+DEL /F %2 2>nul
+FOR /F "tokens=* delims=" %%G IN (%1) DO (
+	SET _pref=%%G
+	SET "_temp=!_pref: =!"
+	IF /I "!_temp!"=="!_temp:user.js.parrot=!" (
+		IF /I "user"=="!_temp:~0,4!" (
+			FOR /F "delims=," %%S IN ("!_pref!") DO (
+				SET _pref=%%S
+			)
+			SET _pref=!_pref:"=""!
+			FIND /I "!_pref!" %2 >nul 2>&1
+			IF ERRORLEVEL 1 (
+				FIND /I "!_pref!" %1 >temp1
+				FOR /F "tokens=* delims=" %%X IN (temp1) DO (
+					SET _temp=%%X
+					SET "_temp=!_temp: =!"
+					IF /I "user"=="!_temp:~0,4!" (
+						SET _pref=%%X
+					)
+				)
+				ECHO !_pref!>>%2
+			)
+		) ELSE (
+			ECHO !_pref!>>%2
+		)
+	) ELSE (
+		ECHO !_pref!>>%2
+	)
+)
+DEL /F %1 temp1 2>nul
+EXIT /B
+REM ############################
+:begin
 SET /A "_line=0"
 IF NOT EXIST user.js (
 	ECHO user.js not detected in the current directory.
@@ -58,7 +116,7 @@ IF NOT EXIST user.js (
 	:exitloop
 	IF !_line! GEQ 4 (
 		IF /I NOT "!_name!"=="!_name:ghacks=X!" (
-			ECHO ghacks user.js !_version:~2!,!_date!
+			ECHO ghacks user.js !_version:*version=version!,!_date!
 		) ELSE (
 			ECHO Current user.js version not recognised.
 		)
@@ -74,7 +132,9 @@ IF NOT DEFINED _ua (
 	REM ECHO Visit the wiki for more detailed information.
 	REM ECHO.
 	CHOICE /M "Continue"
-	IF ERRORLEVEL 2 EXIT /B
+	IF ERRORLEVEL 2 (
+		EXIT /B
+	)
 )
 CLS
 ECHO.
@@ -91,7 +151,7 @@ IF DEFINED _log (
 	ECHO.
 )
 IF EXIST user.js (
-	IF EXIST user.js.bak REN user.js.bak user.js.old.bak
+	REN user.js.bak user.js.old.bak >nul 2>&1
 	REN user.js user.js.bak
 	ECHO Current user.js file backed up.
 	ECHO.
@@ -108,6 +168,7 @@ IF EXIST user.js (
 				ECHO.
 				ECHO Merging...
 				ECHO.
+				DEL /F user-overrides-merged.js temp2 2>nul
 				COPY /B /V /Y user.js-overrides\*.js user-overrides
 				CALL :merge user-overrides user-overrides-merged.js
 				COPY /B /V /Y user.js+user-overrides-merged.js temp2
@@ -144,12 +205,12 @@ IF EXIST user.js (
 	ECHO.
 	ECHO.
 	IF "!changed!"=="true" (
-		IF EXIST user.js.old.bak DEL /F user.js.old.bak
+		DEL /F user.js.old.bak 2>nul
 		ECHO Update complete.
 	) ELSE (
 		IF "!changed!"=="false" (
 			DEL /F user.js.bak
-			IF EXIST user.js.old.bak REN user.js.old.bak user.js.bak
+			REN user.js.old.bak user.js.bak >nul 2>&1
 			ECHO Update completed without changes.
 		) ELSE (
 			ECHO Update complete.
@@ -157,8 +218,8 @@ IF EXIST user.js (
 	)
 	ECHO.
 ) ELSE (
-	IF EXIST user.js.bak REN user.js.bak user.js
-	IF EXIST user.js.old.bak REN user.js.old.bak user.js.bak
+	REN user.js.bak user.js >nul 2>&1
+	REN user.js.old.bak user.js.bak >nul 2>&1
 	ECHO.
 	ECHO Update failed. Make sure PowerShell is allowed internet access.
 	ECHO.
@@ -168,45 +229,3 @@ IF EXIST user.js (
 IF NOT DEFINED _log (
 	IF NOT DEFINED _ua PAUSE
 )
-EXIT /B
-
-REM ###### Merge function ######
-:merge
-DEL /F %2 2>nul
-SETLOCAL disabledelayedexpansion
-FOR /F "tokens=1,* delims=]" %%G IN ('find /n /v "" ^< "%~1"') DO (
-	SET "_pref=%%H"
-	SETLOCAL enabledelayedexpansion
-	SET "_temp=!_pref: =!"
-	IF /I "user_pref"=="!_temp:~0,9!" (
-		IF /I NOT "user.js.parrot"=="!_temp:~12,14!" (
-			FOR /F "delims=," %%S IN ("!_pref!") DO (
-				SET "_pref=%%S"
-			)
-			SET _pref=!_pref:"=""!
-			FIND /I "!_pref!" %~2 >nul 2>&1
-			IF ERRORLEVEL 1 (
-				FIND /I "!_pref!" %~1 >temp123
-				FOR /F "tokens=* delims=" %%X IN (temp123) DO (
-					SET "_temp=%%X"
-					SET "_temp=!_temp: =!"
-					IF /I "user_pref"=="!_temp:~0,9!" (
-						SET "_pref=%%X"
-					)
-				)
-				ECHO(!_pref!>>%~2
-			)
-		) ELSE (
-			ECHO(!_pref!>>%~2
-		)
-	) ELSE (
-		ECHO(!_pref!>>%~2
-	)
-	ENDLOCAL
-)
-ENDLOCAL
-DEL /F %~1 temp123 >nul
-GOTO EOF
-REM ############################
-
-:EOF

--- a/updater.bat
+++ b/updater.bat
@@ -61,24 +61,29 @@ IF DEFINED _updateb (
 GOTO begin
 REM ###### Merge function ######
 :merge
+DEL /F %2 2>nul
 FOR /F "tokens=* delims=" %%G IN (%1) DO (
 	SET _pref=%%G
 	SET "_temp=!_pref: =!"
-	IF /I "user"=="!_temp:~0,4!" (
-		FOR /F "delims=," %%S IN ("!_pref!") DO (
-			SET _pref=%%S
-		)
-		SET _pref=!_pref:"=""!
-		FIND /I "!_pref!" %2 >nul 2>&1
-		IF ERRORLEVEL 1 (
-			FIND /I "!_pref!" %1 >temp1
-			FOR /F "tokens=* delims=" %%X IN (temp1) DO (
-				SET _temp=%%X
-				SET "_temp=!_temp: =!"
-				IF /I "user"=="!_temp:~0,4!" (
-					SET _pref=%%X
-				)
+	IF /I "user.js.parrot"=="!_temp:user.js.parrot=!"
+		IF /I "user"=="!_temp:~0,4!" (
+			FOR /F "delims=," %%S IN ("!_pref!") DO (
+				SET _pref=%%S
 			)
+			SET _pref=!_pref:"=""!
+			FIND /I "!_pref!" %2 >nul 2>&1
+			IF ERRORLEVEL 1 (
+				FIND /I "!_pref!" %1 >temp1
+				FOR /F "tokens=* delims=" %%X IN (temp1) DO (
+					SET _temp=%%X
+					SET "_temp=!_temp: =!"
+					IF /I "user"=="!_temp:~0,4!" (
+						SET _pref=%%X
+					)
+				)
+				ECHO !_pref!>>%2
+			)
+		) ELSE (
 			ECHO !_pref!>>%2
 		)
 	) ELSE (
@@ -163,13 +168,11 @@ IF EXIST user.js (
 				ECHO.
 				ECHO Merging...
 				ECHO.
-				DEL /F user-overrides-merged.js temp2 temp3 2>nul
+				DEL /F user-overrides-merged.js temp2 2>nul
 				COPY /B /V /Y user.js-overrides\*.js user-overrides
 				CALL :merge user-overrides user-overrides-merged.js
 				COPY /B /V /Y user.js+user-overrides-merged.js temp2
-				DEL /F user.js 2>nul
 				CALL :merge temp2 user.js
-				REN temp3 user.js
 			) ELSE (
 				ECHO.
 				ECHO Appending...


### PR DESCRIPTION
- Added `-updatebatch` switch so the updater can auto update itself on execution. This is the only case-sensitive switch.
- Added new `-LogP` switch, that works just like -Log, but also opens the log file after updating.
- Added new `-MultiOverrides` switch, that uses any and all .js files in a 'user.js-overrides' sub-folder as overrides instead of the default 'user-overrides.js' file. Files are appended in alphabetical order.
- Added new `-Merge` switch, that uses a new algorithm to merge overrides instead of appending them. Files are parsed in alphabetical order and when there are conflicting records, the values of the last ones declared are the ones used. The order of said records doesn't change in the resulting file. Comments are appended normally. When the script is run with both `-Merge` and `-MultiOverrides` switches, an 'user-overrides-merged.js' file is also generated in the root directory for quick reference. Said file contains only the merged data from override files and can be safely discarded after updating.

For a more full list of changes, with jokes and nasty surprises, see my epic fail (#286).

@earthlng have fun testing 😆 