### PR TITLE
Convert BAT line-endings to CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,6 @@
 *.md text
 *.yml text
 *.txt text
+*.bat text eol=crlf
 
 *.png binary


### PR DESCRIPTION
LF is messing with calls to :message in the updater, at least on my end.

EDIT: Curiously, the updater seems to have CRLF EOL's in the repository, but GitHub still hands out LF versions [here](https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.bat) and [here](https://github.com/ghacksuserjs/ghacks-user.js/raw/master/updater.bat), which makes me wonder if this can be fixed at all. I guess it ultimately means the `-updatebatch` switch produces unexpected results.

### STR:
1. Start the updater with `-updatebatch` switch. Let it update itself.
2. Press H in the menu to see the available switches, and you should see CALL errors where the names of the switches would be.
3. Close the updater.
4. Change line endings to CRLF using Notepad++ or the like.
5. Start the updater **without** `-updatebatch` switch.
6. Repeat step 2. Errors should be gone.

I'm leaving this PR open because even if this may not fix the issue, it can't make things worse.