### PR TITLE
updater for Windows v4.5

### DIFF
--- a/updater.bat
+++ b/updater.bat
@@ -213,6 +213,7 @@ FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/ comment-out .*"
 								SETLOCAL EnableDelayedExpansion
 								FOR /F "delims=" %%L IN ("!%%K!") DO (
 									ENDLOCAL & ECHO:user_pref("%%K"%%L
+									SET "%%K="
 								)
 							)
 						)

--- a/updater.bat
+++ b/updater.bat
@@ -3,7 +3,7 @@ TITLE ghacks user.js updater
 
 REM ## ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 4.4
+REM ## version: 4.5
 REM ## instructions: https://github.com/ghacksuserjs/ghacks-user.js/wiki/3.3-Updater-Scripts
 
 SET _myname=%~n0
@@ -75,7 +75,7 @@ ECHO:
 ECHO:                ########################################
 ECHO:                ####  user.js Updater for Windows   ####
 ECHO:                ####       by claustromaniac        ####
-ECHO:                ####             v4.4               ####
+ECHO:                ####             v4.5               ####
 ECHO:                ########################################
 ECHO:
 SET /A "_line=0"
@@ -191,8 +191,9 @@ GOTO :EOF
 REM ############ Merge function ############
 :merge
 SETLOCAL DisableDelayedExpansion
+FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /B /R /C:"user_pref.*\)[    ]*;" "%~1"') DO (IF NOT "%%H"=="" (SET "%%G=%%H"))
+FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/ comment-out .*" "%~1"') DO (SET "__unset__%%G=1")
 (
-	FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /B /R /C:"user_pref.*\)[ 	]*;" "%~1"') DO (IF NOT "%%H"=="" (SET "%%G=%%H"))
 	FOR /F "tokens=1,* delims=:" %%I IN ('FINDSTR /N "^" "%~1"') DO (
 		SET "_temp=%%J"
 		SETLOCAL EnableDelayedExpansion
@@ -205,11 +206,14 @@ SETLOCAL DisableDelayedExpansion
 				ENDLOCAL
 				FOR /F tokens^=2^ delims^=^'^" %%K IN ("%%J") DO (
 					IF NOT "_user.js.parrot"=="%%K" (
-						IF DEFINED %%K (
-							SETLOCAL EnableDelayedExpansion
-							FOR /F "delims=" %%L IN ("!%%K!") DO (
-								ENDLOCAL & ECHO:user_pref("%%K"%%L
-								SET "%%K="
+						IF DEFINED __unset__%%K (
+							ECHO://%%J
+						) ELSE (
+							IF DEFINED %%K (
+								SETLOCAL EnableDelayedExpansion
+								FOR /F "delims=" %%L IN ("!%%K!") DO (
+									ENDLOCAL & ECHO:user_pref("%%K"%%L
+								)
 							)
 						)
 					) ELSE (ECHO:%%J)

--- a/updater.bat
+++ b/updater.bat
@@ -191,8 +191,8 @@ GOTO :EOF
 REM ############ Merge function ############
 :merge
 SETLOCAL DisableDelayedExpansion
-FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /B /R /C:"user_pref.*\)[    ]*;" "%~1"') DO (IF NOT "%%H"=="" (SET "%%G=%%H"))
-FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/ comment-out .*" "%~1"') DO (SET "__unset__%%G=1")
+FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /B /R /C:"user_pref[ 	]*\([ 	]*[\"'][^\"'][^\"']*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
+FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/\/\/ --- comment-out --- \"[^\"][^\"]*\".*" "%~1"') DO (SET "__unset__%%G=1")
 (
 	FOR /F "tokens=1,* delims=:" %%I IN ('FINDSTR /N "^" "%~1"') DO (
 		SET "_temp=%%J"
@@ -209,11 +209,11 @@ FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/ comment-out .*"
 						IF DEFINED __unset__%%K (
 							ECHO://%%J
 						) ELSE (
-							IF DEFINED %%K (
+							IF DEFINED [%%K] (
 								SETLOCAL EnableDelayedExpansion
-								FOR /F "delims=" %%L IN ("!%%K!") DO (
+								FOR /F "delims=" %%L IN ("![%%K]!") DO (
 									ENDLOCAL & ECHO:user_pref("%%K"%%L
-									SET "%%K="
+									SET "[%%K]="
 								)
 							)
 						)

--- a/updater.bat
+++ b/updater.bat
@@ -191,8 +191,8 @@ GOTO :EOF
 REM ############ Merge function ############
 :merge
 SETLOCAL DisableDelayedExpansion
-FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /B /R /C:"user_pref[ 	]*\([ 	]*[\"'][^\"'][^\"']*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
-FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /B /R /C:"\/\/\/\/ --- comment-out --- \"[^\"][^\"]*\".*" "%~1"') DO (SET "__unset__%%G=1")
+FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /R /C:"^user_pref[ 	]*\([ 	]*[\"'][a-z].*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
+FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /R /C:"^//// --- comment-out --- \"[a-z].*\".*" "%~1"') DO (SET "__unset__%%G=1")
 (
 	FOR /F "tokens=1,* delims=:" %%I IN ('FINDSTR /N "^" "%~1"') DO (
 		SET "_temp=%%J"

--- a/updater.bat
+++ b/updater.bat
@@ -192,7 +192,7 @@ REM ############ Merge function ############
 :merge
 SETLOCAL DisableDelayedExpansion
 FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /R /C:"^user_pref[ 	]*\([ 	]*[\"'][a-z].*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
-FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /R /C:"^//// --- comment-out --- \"[a-z].*\".*" "%~1"') DO (SET "__unset__%%G=1")
+FOR /F tokens^=2^,^*^ delims^=^' %%G IN ('FINDSTR /R /C:"^//// --- comment-out --- '[a-z][^']*'.*" "%~1"') DO (SET "__unset__%%G=1")
 (
 	FOR /F "tokens=1,* delims=:" %%I IN ('FINDSTR /N "^" "%~1"') DO (
 		SET "_temp=%%J"
@@ -205,19 +205,17 @@ FOR /F tokens^=2^,^*^ delims^=^" %%G IN ('FINDSTR /R /C:"^//// --- comment-out -
 			) ELSE (
 				ENDLOCAL
 				FOR /F tokens^=2^ delims^=^'^" %%K IN ("%%J") DO (
-					IF NOT "_user.js.parrot"=="%%K" (
-						IF DEFINED __unset__%%K (
-							ECHO://%%J
-						) ELSE (
-							IF DEFINED [%%K] (
-								SETLOCAL EnableDelayedExpansion
-								FOR /F "delims=" %%L IN ("![%%K]!") DO (
-									ENDLOCAL & ECHO:user_pref("%%K"%%L
-									SET "[%%K]="
-								)
+					IF DEFINED __unset__%%K (
+						ECHO://%%J
+					) ELSE (
+						IF DEFINED [%%K] (
+							SETLOCAL EnableDelayedExpansion
+							FOR /F "delims=" %%L IN ("![%%K]!") DO (
+								ENDLOCAL & ECHO:user_pref("%%K"%%L
+								SET "[%%K]="
 							)
 						)
-					) ELSE (ECHO:%%J)
+					)
 				)
 			)
 		)

--- a/updater.bat
+++ b/updater.bat
@@ -205,17 +205,19 @@ FOR /F tokens^=2^,^*^ delims^=^' %%G IN ('FINDSTR /R /C:"^//// --- comment-out -
 			) ELSE (
 				ENDLOCAL
 				FOR /F tokens^=2^ delims^=^'^" %%K IN ("%%J") DO (
-					IF DEFINED __unset__%%K (
-						ECHO://%%J
-					) ELSE (
-						IF DEFINED [%%K] (
-							SETLOCAL EnableDelayedExpansion
-							FOR /F "delims=" %%L IN ("![%%K]!") DO (
-								ENDLOCAL & ECHO:user_pref("%%K"%%L
-								SET "[%%K]="
+					IF NOT "_user.js.parrot"=="%%K" (
+						IF DEFINED __unset__%%K (
+							ECHO://%%J
+						) ELSE (
+							IF DEFINED [%%K] (
+								SETLOCAL EnableDelayedExpansion
+								FOR /F "delims=" %%L IN ("![%%K]!") DO (
+									ENDLOCAL & ECHO:user_pref("%%K"%%L
+									SET "[%%K]="
+								)
 							)
 						)
-					)
+					) ELSE (ECHO:%%J)
 				)
 			)
 		)

--- a/updater.bat
+++ b/updater.bat
@@ -191,8 +191,8 @@ GOTO :EOF
 REM ############ Merge function ############
 :merge
 SETLOCAL DisableDelayedExpansion
-FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /R /C:"^user_pref[ 	]*\([ 	]*[\"'][a-z].*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
-FOR /F tokens^=2^,^*^ delims^=^' %%G IN ('FINDSTR /R /C:"^//// --- comment-out --- '[a-z][^']*'.*" "%~1"') DO (SET "__unset__%%G=1")
+FOR /F tokens^=2^,^*^ delims^=^'^" %%G IN ('FINDSTR /R /C:"^user_pref[ 	]*\([ 	]*[\"'].*[\"'][ 	]*,.*\)[ 	]*;" "%~1"') DO (SET "[%%G]=%%H")
+FOR /F tokens^=2^,^*^ delims^=^' %%G IN ('FINDSTR /R /C:"^//// --- comment-out --- '[^'][^']*'.*" "%~1"') DO (SET "__unset__%%G=1")
 (
 	FOR /F "tokens=1,* delims=:" %%I IN ('FINDSTR /N "^" "%~1"') DO (
 		SET "_temp=%%J"


### PR DESCRIPTION
supports commenting-out active user-prefs with the merge function.

It needs a line like this in an override file:
```js
// comment-out "security.tls.version.max" = 1202 - wait until FF enables TLS1.3 for everyone by default
```
such a line has to start at column 0 with a double forward-slash followed by a single space, lowercase `comment` `minus` `out`, single space and the prefname in double quotes. Anything after that is optional and can be used for a reminder comment or whatever.

But maybe we should make the format a bit more uncommon, like with 4 slashes or so.