### PR TITLE
Improve updater.sh

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -7,7 +7,7 @@
 #
 # Special requirements (beyond Bash): wget and mktemp.
 #
-# Version: 1.4
+# Version: 2.0
 #
 # Please read the wiki or run 'updater.sh --help' to get informations about this
 # script.

--- a/updater.sh
+++ b/updater.sh
@@ -218,8 +218,15 @@ while :; do
     --help|-h) shift;             SHOW_HELP="true";;
     --version|-v) shift;          SHOW_VERSION="true";;
     --backup|-b) shift;           MAKE_BACKUP="true";;
+
+    # Deprecated options.
+    -donotupdate) shift;          warn "'-donotupdate' is a deprecated option";;
+    -update) shift;               warn "'-update' is a deprecated option";;
+
+    # Special cases.
     "")                           break;; # Default case: no more options.
     *)                            error "Unrecognized option '$1'";;
+
   esac
 done
 

--- a/updater.sh
+++ b/updater.sh
@@ -1,119 +1,100 @@
 #!/usr/bin/env bash
+#
+# ghacks-user.js updater for GNU/Linux and Mac.
+#
+# Copyright (C) 2018 Emanuele Petriglia <inbox@emanuelepetriglia.me>.
+# All right reserved. This file is licensed under the MIT license.
+#
+# Version: 1.4
+#
+# Please read the wiki or run 'updater.sh --help' to get informations about this
+# script.
 
-### ghacks-user.js updater for Mac/Linux
-## author: @overdodactyl
-## version: 1.3
+# Default values for flags.
+QUIET="false"
+VERBOSE="false"
+FORCE_VERSION="false"
+UPDATED="false"
 
-## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in check_for_update() )
-
-ghacksjs="https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js"
-updater="https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh"
-update_pref=${1:--ask}
-
-currdir=$(pwd)
-
-## get the full path of this script (readlink for Linux, greadlink for Mac with coreutils installed)
-sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
-
-## fallback for Macs without coreutils
-if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
-
-## change directory to the Firefox profile directory
-cd "$(dirname "${sfp}")"
-
-## Used to check if a new version of updater.sh is available
-update_available="no"
-check_for_update () {
-  online_version="$(curl -s ${updater} | sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p')"
-  path_to_script="$(dirname "${sfp}")/updater.sh"
-  current_version="$(sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p' "$path_to_script")"
-  if [[ "$current_version" < "$online_version" ]]; then
-    update_available="yes"
-  fi
-}
-
-## Used to backup the current script, and download and execute the latest version of updater.sh
-update_script () {
-  echo -e "This script will be backed up and the latest version of updater.sh will be executed.\n"
-  mv updater.sh "updater.sh.backup.$(date +"%Y-%m-%d_%H%M")"
-  curl -O ${updater} && echo -e "\nThe latest updater script has been downloaded\n"
-  
-  # make new file executable
-  chmod +x updater.sh
-
-  # execute new updater script
-  ./updater.sh -donotupdate
-
-  # exit script
+# Prints a message to the standard error and exit with error code 1.
+error() {
+  echo -e "$@" >&2
   exit 1
 }
 
-
-main () {
-  ## create backup folder if it doesn't exist
-  mkdir -p userjs_backups;
-
-  echo -e "\nThis script should be run from your Firefox profile directory.\n"
-
-  echo -e "Updating the user.js for Firefox profile:\n$(pwd)\n"
-
-  if [ -e user.js ]; then
-    echo "Your current user.js file for this profile will be backed up and the latest ghacks version from github will take its place."
-    echo -e "\nIf currently using the ghacks user.js, please compare versions:"
-    echo "  Available online: $(curl -s ${ghacksjs} | sed -n '4p')"
-    echo "  Currently using:  $(sed -n '4p' user.js)"
-  else
-    echo "A user.js file does not exist in this profile. If you continue, the latest ghacks version from github will be downloaded."
+# Prints a message to the standard erorr without terminate execution.
+warn() {
+  if [[ "$QUIET" == "false" ]]; then
+    echo -e "$@" >&2
   fi
-
-  echo -e "\nIf a user-overrides.js file exists in this profile, it will be appended to the user.js.\n"
-
-  read -p "Continue Y/N? " -n 1 -r
-  echo -e "\n\n"
-
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    if [ -e user.js ]; then
-      # backup current user.js
-      bakfile="userjs_backups/user.js.backup.$(date +"%Y-%m-%d_%H%M")"
-      mv user.js "${bakfile}" && echo "Your previous user.js file was backed up: ${bakfile}"
-    fi
-
-    # download latest ghacks user.js
-    echo "downloading latest ghacks user.js file"
-    curl -O ${ghacksjs} && echo "ghacks user.js has been downloaded"
-
-    if [ -e user-overrides.js ]; then
-      echo "user-overrides.js file found"
-      cat user-overrides.js >> user.js && echo "user-overrides.js has been appended to user.js"
-    fi
-  else
-    echo "Process aborted"
-  fi
-
-  ## change directory back to the original working directory
-  cd "${currdir}"
 }
 
-update_pref="$(echo $update_pref | tr '[A-Z]' '[a-z]')"
-if [ $update_pref = "-donotupdate" ]; then
-  main
-else
-  check_for_update
-  if [ $update_available = "no" ]; then
-    main
-  else
-    ## there is an update available 
-    if [ $update_pref = "-update" ]; then
-      ## update without asking
-      update_script
-    else 
-      read -p "There is a newer version of updater.sh available.  Download and execute?  Y/N? " -n 1 -r
-      echo -e "\n\n"
-      if [[ $REPLY =~ ^[Yy]$ ]]; then
-        update_script
-      else
-        main
-      fi
-    fi
+# Prints a message to the standard output.
+log() {
+  if [[ "$VERBOSE" == "true" && "$QUIET" == "false" ]]; then
+    echo -e "$@"
   fi
-fi
+}
+
+# Updates the installer script. It set "true" the variable UPDATED if this
+# script is succesfully updated.
+update_installer() {
+  local TMPFILE="$(mktemp)"
+  local UPDATER_URL="https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh"
+
+  log "Downloading latest updater.sh script to $TMPFILE..."
+  wget --quiet --output-document "$TMPFILE" "$UPDATER_URL"
+
+  if [[ "$?" == "0" ]]; then
+    log "Updater script succesfully downloaded!"
+    UPDATED="true"
+  else
+    warn "Failed to download the updater script."
+  fi
+
+  mv "$TMPFILE" "UPDATER.SH"
+}
+
+# Prints to the standard output the help message.
+show_help() {
+  echo "ciao"
+}
+
+# Prints to the standard output the version of this script.
+show_version() {
+  echo "$PROGRAM version 1.4"
+}
+
+# Updates the user.js.
+update_userjs() {
+  # Run the recenlty downloader version of this script.
+  if [[ "$UPDATED" == "true" ]]; then
+    source "$PROGRAM" $@
+    exit 0
+  fi
+}
+
+# Check if a program is installed. If it is not installed prints an error.
+check_utily() {
+  if [[ -z $(command -v "$1") ]]; then
+    error "$1 is not installed. Please install it before executing this script"
+  fi
+}
+
+PROGRAM="${0##*/}"
+
+check_utily "wget"
+check_utily "mktemp"
+
+case "$1" in
+  --update|-u) shift;           update_installer "$@";;
+  --force-version|-f) shift;    FORCE_VERSION="yes";;
+  --quiet|-q) shift;            QUIET="yes";;
+  --verbose) shift;             VERBOSE="true";;
+  --help|-h) shift;             show_help;;
+  --version|-v) shift;          show_version;;
+esac
+
+update_userjs
+
+exit 0

--- a/updater.sh
+++ b/updater.sh
@@ -5,17 +5,23 @@
 # Copyright (C) 2018 Emanuele Petriglia <inbox@emanuelepetriglia.me>.
 # All right reserved. This file is licensed under the MIT license.
 #
+# Special requirements (beyond Bash): wget and mktemp.
+#
 # Version: 1.4
 #
 # Please read the wiki or run 'updater.sh --help' to get informations about this
 # script.
+#
+# Report bugs to https://github.com/ghacksuserjs/ghacks-user.js/issues
+
+readonly VERSION="1.4"
 
 # Default values for flags.
 QUIET="false"
 VERBOSE="false"
 FORCE_VERSION="false"
 UPDATED="false"
-VERSION="1.4"
+
 
 # Prints a message to the standard error and exit with error code 1.
 error() {
@@ -73,6 +79,8 @@ Options:
     --help              Print this message
     --version           Print script version
 
+Please run this script from your Firefox profile directory.
+
 Please note that it is not given the option '--force-version' this script will
 download the latest version available, that can be unstable.
 
@@ -87,11 +95,12 @@ show_version() {
 
 # Updates the user.js.
 update_userjs() {
-  # Run the recenlty downloader version of this script.
+  # Run the recently downloader version of this script.
   if [[ "$UPDATED" == "true" ]]; then
     source "$PROGRAM" $@
     exit 0
   fi
+  echo "aggiornato"
 }
 
 # Check if a program is installed. If it is not installed prints an error.
@@ -106,14 +115,41 @@ PROGRAM="${0##*/}"
 check_utily "wget"
 check_utily "mktemp"
 
-case "$1" in
-  --update|-u) shift;           update_installer "$@";;
-  --force-version|-f) shift;    FORCE_VERSION="yes";;
-  --quiet|-q) shift;            QUIET="yes";;
-  --verbose) shift;             VERBOSE="true";;
-  --help|-h) shift;             show_help;;
-  --version|-v) shift;          show_version;;
-esac
+UPDATE_INSTALLER="false"
+SHOW_HELP="false"
+SHOW_VERSION="false"
+
+# Parse command line options.
+while :; do
+  case "$1" in
+    --update|-u) shift;           UPDATE_INSTALLER="true";;
+    --force-version|-f) shift;    FORCE_VERSION="true";;
+    --quiet|-q) shift;            QUIET="true";;
+    --verbose) shift;             VERBOSE="true";;
+    --help|-h) shift;             SHOW_HELP="true";;
+    --version|-v) shift;          SHOW_VERSION="true";;
+    "")                           break;; # Default case: no more options.
+    *)                            error "Unrecognized option '$1'";;
+  esac
+done
+
+if [[ "$VERBOSE" == "true" && "$QUIET" == "true" ]]; then
+  error "You can't use '--verbose' and '--quiet' options together"
+fi
+
+if [[ "$SHOW_HELP" == "true" ]]; then
+  show_help
+  exit 0
+fi
+
+if [[ "$SHOW_VERSION" == "true" ]]; then
+  show_version
+  exit 0
+fi
+
+if [[ "$UPDATE_INSTALLER" == "true" ]]; then
+  update_installer
+fi
 
 update_userjs
 

--- a/updater.sh
+++ b/updater.sh
@@ -28,21 +28,21 @@ UPDATED="false"
 
 # Prints a message to the standard error and exit with error code 1.
 error() {
-  echo -e "$@" >&2
+  echo "[Error] $@" >&2
   exit 1
 }
 
 # Prints a message to the standard erorr without terminate execution.
 warn() {
   if [[ "$QUIET" == "false" ]]; then
-    echo -e "$@" >&2
+    echo "[Warning] $@" >&2
   fi
 }
 
 # Prints a message to the standard output.
 log() {
   if [[ "$VERBOSE" == "true" && "$QUIET" == "false" ]]; then
-    echo -e "$@"
+    echo "[Log] $@"
   fi
 }
 

--- a/updater.sh
+++ b/updater.sh
@@ -15,6 +15,7 @@ QUIET="false"
 VERBOSE="false"
 FORCE_VERSION="false"
 UPDATED="false"
+VERSION="1.4"
 
 # Prints a message to the standard error and exit with error code 1.
 error() {
@@ -57,12 +58,31 @@ update_installer() {
 
 # Prints to the standard output the help message.
 show_help() {
-  echo "ciao"
+  show_version
+  cat <<-_EOF
+Usage:
+    $PROGRAM [--update,-u] [--verbose] [--quiet,-q] [--force-version,-f]
+               [--help,-h] [--version,-v]
+
+Options:
+    -u, --update        First updates the updater script, then the user.js
+    --force-version, -f Force to download the user.js according to the
+                        Firefox version
+    --quiet, -q         Print only errors
+    --verbose           Print additional informations
+    --help              Print this message
+    --version           Print script version
+
+Please note that it is not given the option '--force-version' this script will
+download the latest version available, that can be unstable.
+
+Please report bugs to https://github.com/ghacksuserjs/ghacks-user.js/issues
+_EOF
 }
 
 # Prints to the standard output the version of this script.
 show_version() {
-  echo "$PROGRAM version 1.4"
+  echo "$PROGRAM for ghacks-user.js version $VERSION"
 }
 
 # Updates the user.js.

--- a/updater.sh
+++ b/updater.sh
@@ -36,7 +36,7 @@ log() {
   fi
 }
 
-# Updates the installer script. It set "true" the variable UPDATED if this
+# Updates the installer script. It sets "true" the variable UPDATED if this
 # script is succesfully updated.
 update_installer() {
   local TMPFILE="$(mktemp)"
@@ -49,7 +49,7 @@ update_installer() {
     log "Updater script succesfully downloaded!"
     UPDATED="true"
   else
-    warn "Failed to download the updater script."
+    error "Failed to download the updater script."
   fi
 
   mv "$TMPFILE" "UPDATER.SH"

--- a/updater.sh
+++ b/updater.sh
@@ -14,14 +14,14 @@
 #
 # Report bugs to https://github.com/ghacksuserjs/ghacks-user.js/issues
 
-readonly VERSION="1.4"
+readonly VERSION="2.0"
 
 # Default values for flags.
 QUIET="false"
 VERBOSE="false"
 FORCE_VERSION="false"
 UPDATED="false"
-
+MAKE_BACKUP="false"
 
 # Prints a message to the standard error and exit with error code 1.
 error() {
@@ -68,12 +68,13 @@ show_help() {
   cat <<-_EOF
 Usage:
     $PROGRAM [--update,-u] [--verbose] [--quiet,-q] [--force-version,-f]
-               [--help,-h] [--version,-v]
+               [--help,-h] [--version,-v] [--backup,-b]
 
 Options:
     -u, --update        First updates the updater script, then the user.js
     --force-version, -f Force to download the user.js according to the
                         Firefox version
+    --backup, -b        Make a copy of the old user.js before overwriting it
     --quiet, -q         Print only errors
     --verbose           Print additional informations
     --help              Print this message
@@ -128,6 +129,7 @@ while :; do
     --verbose) shift;             VERBOSE="true";;
     --help|-h) shift;             SHOW_HELP="true";;
     --version|-v) shift;          SHOW_VERSION="true";;
+    --backup|-b) shift;           MAKE_BACKUP="true";;
     "")                           break;; # Default case: no more options.
     *)                            error "Unrecognized option '$1'";;
   esac


### PR DESCRIPTION
Hi, I've completely rewritten the script `updater.sh` because I think that the old one was [too verbose](http://www.linfo.org/rule_of_silence.html) and did many useless things (but I respect the original author).

Feature of the new version:

- Basic options (see down) handling;
- Use `wget` instead of `curl`, because wget is more widespread (on GNU/Linux is pratically preinstalled);
- It can install `user.js` version according to Firefox version installed on the computer (for example if I have Firefox 59.0, It will download `user.js` for that version and not the latest).

Options available:

-  `-u`, `--update `       First updates the updater script, then the user.js
- `--force-version`, `-f` Force to download the user.js according to the Firefox version
- `--backup`, `-b`        Make a copy of the old user.js before overwriting it
-  `--quiet`, `-q`         Print only errors
- `--verbose`           Print additional informations
- `--help`            Print this message
- `--version`           Print script version

I've tested this script on my computer with Debian 9, it should work on any GNU/Linux distributions. I don't have a Mac, so I ask help for testing it on this platform (but It should work flawlessy). This script needs also a minimal code review.

In short, thanks for all what are you doing, this project is very useful both for documenting `user.js` and improve the privacy on Web.

If this pull requests will be merged I also take care of updating the wiki.
