### PR TITLE
Use wget if curl is not available

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -2,7 +2,7 @@
 
 ### ghacks-user.js updater for Mac/Linux
 ## author: @overdodactyl, @ema-pe
-## version: 1.3
+## version: 1.4
 
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in check_for_update() )
 

--- a/updater.sh
+++ b/updater.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ### ghacks-user.js updater for Mac/Linux
-## author: @overdodactyl
+## author: @overdodactyl, @ema-pe
 ## version: 1.3
 
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in check_for_update() )
@@ -11,6 +11,15 @@ updater="https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/up
 update_pref=${1:--ask}
 
 currdir=$(pwd)
+
+DOWNLOAD_TO_STDOUT="curl -s"
+DOWNLOAD_TO_FILE="curl -O"
+
+# Use wget if curl is not available.
+if [[ -z $(command -v "curl") ]]; then
+  DOWNLOAD_TO_STDOUT="wget --quiet --output-document=-"
+  DOWNLOAD_TO_FILE="wget"
+fi
 
 ## get the full path of this script (readlink for Linux, greadlink for Mac with coreutils installed)
 sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
@@ -24,7 +33,7 @@ cd "$(dirname "${sfp}")"
 ## Used to check if a new version of updater.sh is available
 update_available="no"
 check_for_update () {
-  online_version="$(curl -s ${updater} | sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p')"
+  online_version="$($DOWNLOAD_TO_STDOUT ${updater} | sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p')"
   path_to_script="$(dirname "${sfp}")/updater.sh"
   current_version="$(sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p' "$path_to_script")"
   if [[ "$current_version" < "$online_version" ]]; then
@@ -36,8 +45,8 @@ check_for_update () {
 update_script () {
   echo -e "This script will be backed up and the latest version of updater.sh will be executed.\n"
   mv updater.sh "updater.sh.backup.$(date +"%Y-%m-%d_%H%M")"
-  curl -O ${updater} && echo -e "\nThe latest updater script has been downloaded\n"
-  
+  $DOWNLOAD_TO_FILE ${updater} && echo -e "\nThe latest updater script has been downloaded\n"
+
   # make new file executable
   chmod +x updater.sh
 
@@ -60,7 +69,7 @@ main () {
   if [ -e user.js ]; then
     echo "Your current user.js file for this profile will be backed up and the latest ghacks version from github will take its place."
     echo -e "\nIf currently using the ghacks user.js, please compare versions:"
-    echo "  Available online: $(curl -s ${ghacksjs} | sed -n '4p')"
+    echo "  Available online: $($DOWNLOAD_TO_STDOUT ${ghacksjs} | sed -n '4p')"
     echo "  Currently using:  $(sed -n '4p' user.js)"
   else
     echo "A user.js file does not exist in this profile. If you continue, the latest ghacks version from github will be downloaded."
@@ -80,7 +89,7 @@ main () {
 
     # download latest ghacks user.js
     echo "downloading latest ghacks user.js file"
-    curl -O ${ghacksjs} && echo "ghacks user.js has been downloaded"
+    $DOWNLOAD_TO_FILE ${ghacksjs} && echo "ghacks user.js has been downloaded"
 
     if [ -e user-overrides.js ]; then
       echo "user-overrides.js file found"
@@ -93,6 +102,7 @@ main () {
   ## change directory back to the original working directory
   cd "${currdir}"
 }
+
 
 update_pref="$(echo $update_pref | tr '[A-Z]' '[a-z]')"
 if [ $update_pref = "-donotupdate" ]; then


### PR DESCRIPTION
After the discussion on #447 I decided to send single pull requests improving the existent script instead of writing a new one.

This pull request add `wget` as fallback if `curl` is not installed. Why? Because `wget` is often preinstalled on most GNU/Linux distributions, and the end user doesn't need to install a new software for keeping updated the `user.js`.

If you use `wget` or `curl` the behaviour is the same, only the output can change a bit. For example with curl:

```

This script should be run from your Firefox profile directory.

Updating the user.js for Firefox profile:
/home/emanuele/Projects/ghacks-user.js

Your current user.js file for this profile will be backed up and the latest ghacks version from github will take its place.

If currently using the ghacks user.js, please compare versions:
  Available online: * version 61-alpha: You Can't Hurry Pants
  Currently using:  * version 61-alpha: You Can't Hurry Pants

If a user-overrides.js file exists in this profile, it will be appended to the user.js.

Continue Y/N? y


Your previous user.js file was backed up: userjs_backups/user.js.backup.2018-06-25_1749
downloading latest ghacks user.js file
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  130k  100  130k    0     0   177k      0 --:--:-- --:--:-- --:--:--  177k
ghacks user.js has been downloaded
```

And with `wget`:

```

This script should be run from your Firefox profile directory.

Updating the user.js for Firefox profile:
/home/emanuele/Projects/ghacks-user.js

Your current user.js file for this profile will be backed up and the latest ghacks version from github will take its place.

If currently using the ghacks user.js, please compare versions:
  Available online: * version 61-alpha: You Can't Hurry Pants
  Currently using:  * version 61-alpha: You Can't Hurry Pants

If a user-overrides.js file exists in this profile, it will be appended to the user.js.

Continue Y/N? y


Your previous user.js file was backed up: userjs_backups/user.js.backup.2018-06-25_1749
downloading latest ghacks user.js file
--2018-06-25 17:49:28--  https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.112.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.112.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 133308 (130K) [text/plain]
Saving to: ‘user.js’

user.js                 100%[==============================>] 130.18K   528KB/s    in 0.2s    

2018-06-25 17:49:29 (528 KB/s) - ‘user.js’ saved [133308/133308]

ghacks user.js has been downloaded
```