### PR TITLE
remove old information

### DIFF
--- a/user.js
+++ b/user.js
@@ -1398,8 +1398,7 @@ user_pref("network.cookie.leave-secure-alone", true); // default: true
  * via an extenion. Note that IDB currently cannot be sanitized by host.
  * [1] https://blog.mozilla.org/addons/2018/08/03/new-backend-for-storage-local-api/ ***/
 user_pref("dom.indexedDB.enabled", true); // default: true
-/* 2730: disable offline cache
- * [NOTE] For FF51-FF60 (ESR not included), this is required 'true' for Storage API (2750) ***/
+/* 2730: disable offline cache ***/
 user_pref("browser.cache.offline.enable", false);
 /* 2730b: disable offline cache on insecure sites (FF60+)
  * [1] https://blog.mozilla.org/security/2018/02/12/restricting-appcache-secure-contexts/ ***/
@@ -1415,7 +1414,6 @@ user_pref("dom.caches.enabled", false);
  * The API gives sites the ability to find out how much space they can use, how much
  * they are already using, and even control whether or not they need to be alerted
  * before the user agent disposes of site data in order to make room for other things.
- * [NOTE] For FF51-FF60 (ESR not included), if Storage API is enabled, then Offline Cache (2730) must be also be enabled
  * [1] https://developer.mozilla.org/docs/Web/API/StorageManager
  * [2] https://developer.mozilla.org/docs/Web/API/Storage_API
  * [3] https://blog.mozilla.org/l10n/2017/03/07/firefox-l10n-report-aurora-54/ ***/


### PR DESCRIPTION
Pants said "We do not need to keep anything for ESR users. ESR users are on v60, and we have an archived 60 for them."
This isn't even affecting ESR60 but only older versions.