### PR TITLE
updater_overhaul

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -39,6 +39,7 @@ ff_profile="$(dirname "${sfp}")"
 #     File Handeling    #
 #########################
 
+# Download method priority: curl -> wget -> pearl
 DOWNLOAD_METHOD="not_pearl"
 if [[ $(command -v "curl") ]] > /dev/null 2>&1; then
   DOWNLOAD_TO_FILE="curl -O"  
@@ -60,7 +61,6 @@ download_file () {
   if [ $DOWNLOAD_METHOD = "not_pearl" ]; then
     $DOWNLOAD_TO_FILE ${url}
   else
-    echo ${url}
     http_url=${url/https/http}
     # Variables from the shell are available in Perl's %ENV hash
     # Need to export shell variable so it is visible to subprocesses
@@ -81,7 +81,7 @@ download_file () {
 # Replace current version of a file with new one in userjs_temps
 backup_file () {
   filename=$1
-  #echo -e "This script will be backed up and the latest version of ${filename} will be executed.\n"
+  mkdir -p userjs_backups
   mv $filename "userjs_backups/${filename}.backup.$(date +"%Y-%m-%d_%H%M")"
   mv "userjs_temps/${filename}" $filename
   echo -e "Status: ${GREEN}${filename} has been backed up and replaced with the latest version!${NC}"
@@ -94,12 +94,14 @@ backup_file () {
 initiate () {
   echo -e
   echo -e
-  echo -e        ${BBLUE}"\t\t\t###################################################"
-  echo -e                "\t\t\t####                                           ####"
-  echo -e                "\t\t\t####    user.js updater for macOS and Linux    ####"
-  echo -e                "\t\t\t####              by overdodactyl              ####"
-  echo -e                "\t\t\t####                                           ####"
-  echo -e                "\t\t\t###################################################"${NC}
+  echo -e        ${BBLUE}"  ############################################################################"
+  echo -e                "  ####                                                                    ####"
+  echo -e 				 "  ####                           ghacks user.js                           ####"
+  echo -e                "  ####       Hardening the Privacy and Security Settings of Firefox       ####"
+  echo -e                "  ####           Maintained by @Thorin-Oakenpants and @earthlng           ####"                            ####"
+  echo -e                "  ####            Updater for macOS and Linux by @overdodactyl            ####"            									 ####"
+  echo -e                "  ####                                                                    ####"
+  echo -e                "  ############################################################################"${NC}
   echo -e
   echo -e
   echo -e "Documentation for this script is available here: ${CYAN}https://github.com/ghacksuserjs/ghacks-user.js/wiki/3.3-Updater-Scripts${NC}\n"
@@ -142,7 +144,7 @@ get_updater_version () {
 update_updater () {
   update_pref="$(echo $update_pref | tr '[A-Z]' '[a-z]')"
   if [ $update_pref = "-donotupdate" ]; then
-    # User signified not check for updates
+    # User signified not to check for updates
     return 0
   fi
 
@@ -182,7 +184,6 @@ get_userjs_version () {
 
 # Applies latest version of user.js and any custom overrides
 update_userjs () {
-  mkdir -p userjs_backups
   backup_file user.js
   if [ -e user-overrides.js ]; then
     cat user-overrides.js >> user.js

--- a/updater.sh
+++ b/updater.sh
@@ -31,9 +31,8 @@ currdir=$(pwd)
 sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
 ## fallback for Macs without coreutils
 if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
-## change directory to the Firefox profile directory
+## store the Firefox profile directory
 ff_profile="$(dirname "${sfp}")"
-cd $ff_profile
 
 
 #########################
@@ -48,7 +47,7 @@ elif [[ $(command -v "wget") ]] > /dev/null 2>&1; then
 elif [[ $(command -v "perl") ]]; then
   DOWNLOAD_METHOD="perl"
 else
-  echo -e ${RED}"This script requires curl, wget, or pearl to be installed.\nProcess aborted"${NC}
+  echo -e ${RED}"This script requires curl, wget or perl to be installed.\nProcess aborted"${NC}
   exit 0
 fi
 
@@ -119,7 +118,7 @@ confirmation () {
 
   if [[ $REPLY =~ ^[Nn]$ ]]; then
     echo -e ${RED}"Process aborted"${NC}
-    exit 1
+    return 1
   fi
 }
 
@@ -133,7 +132,6 @@ get_updater_version () {
   filename=$1
   version_regex='5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p'
   echo "$(sed -n "$version_regex" "${ff_profile}/${filename}")"
-
 }
 
 # Update updater.sh
@@ -196,9 +194,11 @@ update_userjs () {
 #        Execute        #
 #########################
 
+## change directory to the Firefox profile directory
+cd "$ff_profile"
+
 initiate
 update_updater
-confirmation
-update_userjs
+confirmation && update_userjs
 rm -rf userjs_temps
 cd "${currdir}"


### PR DESCRIPTION
In large part a restructuring/re-write of the last version.

* Uses `perl` as a last resort if `curl` and `wget`  are not available (fixes #537)
* Aborts and notifies user if none of the above are installed 
* Better use of functions
* When version numbers are checked, the contents are immediately saved to a temp dir.  This allows us to skip using wget/curl/perl a second time
* Improved messages for users
* Added various font colors for ease of use and aesthetics

Pinging @claustromaniac and @earthlng ... any feedback/opinions would be great!