### PR TITLE
Updater args

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -309,11 +309,10 @@ update_userjs () {
     cp user.js userjs_diffs/past_user.js
   fi
   backup_file user.js
-    if [ "$OVERRIDE" != "none" ]; then
-    IFS=',' read -ra FILES <<< "$OVERRIDE"
-    for i in "${FILES[@]}"; do
-        add_override "$i"
-    done
+  if [ "$OVERRIDE" != "none" ]; then
+    while IFS=',' read -ra FILE; do
+      add_override "$FILE"
+    done <<< "$OVERRIDE"
   fi
 }
 

--- a/updater.sh
+++ b/updater.sh
@@ -50,7 +50,7 @@ set_wd () {
     ff_profile="$SCRIPT_DIR"
   elif [ "$PROFILE_PATH" = "list" ]; then
     local firefox_dir=""
-    if [ -d $macdir ]; then
+    if [ -d "$macdir" ]; then
       firefox_dir=$macdir
     elif [ -d $nixdir ]; then
       firefox_dir=$nixdir
@@ -80,7 +80,6 @@ usage() {
   echo -e "\t-h,\t\t Show this help message and exit."
   echo -e "\t-p PROFILE,\t Path to your Firefox profile (if different than the dir of this script)"
   echo -e "\t-l, \t\t Choose your Firefox profile from a list"
-  echo -e "\t\t\t Note: This will not work with portable Firefox installations."
   echo -e "\t\t\t IMPORTANT: if the path include spaces, wrap the entire argument in quotes."
   echo -e "\t-u,\t\t Update updater.sh and execute silently.  Do not seek confirmation."
   echo -e "\t-d,\t\t Do not look for updates to updater.sh."
@@ -176,8 +175,7 @@ get_updater_version () {
 #   -update: Check for update, if available, execute without asking
 update_updater () {
   if [ $UPDATE = "no" ]; then
-    # User signified not to check for updates
-    return 0
+    return 0 # User signified not to check for updates
   fi
 
   declare -r tmpfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh')
@@ -188,13 +186,11 @@ update_updater () {
       read -p "" -n 1 -r
       echo -e "\n\n"
       if [[ $REPLY =~ ^[Nn]$ ]]; then
-        # Update available, but user chooses not to update
-        return 0
+        return 0 # Update available, but user chooses not to update
       fi
     fi
   else
-    # No update available
-    return 0
+    return 0 # No update available
   fi
   mv "${tmpfile}" "${SCRIPT_DIR}/updater.sh"
   chmod u+x "${SCRIPT_DIR}/updater.sh"
@@ -209,7 +205,7 @@ update_updater () {
 
 # Returns version number of a user.js file
 get_userjs_version () {
-  echo $(sed -n '4p' "$1")
+  echo "$(sed -n '4p' "$1")"
 }
 
 add_override () {
@@ -354,8 +350,9 @@ if [ $# != 0 ]; then
           ;;
         r)
           tfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')
-          echo -e ${ORANGE}"Warning: user.js was saved to temporary file ${tfile}"${NC}
-          open "$tfile"
+          mv $tfile "${tfile}.js"
+          echo -e ${ORANGE}"Warning: user.js was saved to temporary file ${tfile}.js"${NC}
+          open "${tfile}.js"
           exit 1
           ;;
         \?)

--- a/updater.sh
+++ b/updater.sh
@@ -54,6 +54,10 @@ usage() {
   echo -e "\t\t\t\t\t Ex: -o \"override folder\" "
   echo -e "\t-n,\t\t Do not append any overrides, even if user-overrides.js exists."
   echo -e
+  echo -e "Deprecated Arguments:"
+  echo -e "\t-donotupdate,\t Use instead -d"
+  echo -e "\t-update,\t Use instead -u"
+  echo -e
   exit 1
 }
 

--- a/updater.sh
+++ b/updater.sh
@@ -40,9 +40,16 @@ set_wd () {
     sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
     if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
     ff_profile="$(dirname "${sfp}")"
+  elif [ "$PROFILE_PATH" = "list" ]; then
+    echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
+    ls -d ~/Library/Application\ Support/Firefox/Profiles/*/
+    echo -e ${RED}"\nWhich profile would you like to update?"${NC}
+    read -p ""
+    echo -e ""
+    ff_profile=$(echo $REPLY | sed s'/.$//')
+    echo $ff_profile
   else
     ff_profile="$PROFILE_PATH"
-    echo "${sfp}"
   fi
     cd "$ff_profile"
 }
@@ -56,6 +63,8 @@ usage() {
   echo -e "Optional Arguments:"
   echo -e "\t-h,\t\t Show this help message and exit."
   echo -e "\t-p PROFILE,\t Path to your Firefox profile (if different than the dir of this script)"
+  echo -e "\t-l, \t\t Choose your Firefox profile from a list"
+  echo -e "\t\t\t Note: This will not work with portable Firefox installations."
   echo -e "\t\t\t IMPORTANT: if the path include spaces, wrap the entire argument in quotes."
   echo -e "\t-u,\t\t Update updater.sh and execute silently.  Do not seek confirmation."
   echo -e "\t-d,\t\t Do not look for updates to updater.sh."
@@ -320,14 +329,17 @@ if [ $# != 0 ]; then
     UPDATE="yes"
     legacy_argument $1
   else
-    while getopts ":hp:udsno:bcvr" opt; do
+    while getopts ":hp:ludsno:bcvr" opt; do
       case $opt in 
         h)
           usage
           ;;
         p)
           PROFILE_PATH=${OPTARG}
-          ;;                         
+          ;;
+        l)
+          PROFILE_PATH="list"
+          ;;                       
         u)
           UPDATE="yes"
           ;;
@@ -375,8 +387,8 @@ fi
 
 ## change directory to the Firefox profile directory
 
-set_wd
 initiate
+set_wd
 update_updater
 confirmation && update_userjs
 create_diff

--- a/updater.sh
+++ b/updater.sh
@@ -172,8 +172,8 @@ backup_file () {
   if [ $BACKUP = "single" ]; then
     bakname="userjs_backups/${filename}.backup"
   fi
-  mv $filename $bakname
-  mv "userjs_temps/${filename}" $filename
+  mv "$filename" "$bakname"
+  mv "userjs_temps/${filename}" "$filename"
   echo -e "Status: ${GREEN}${filename} has been backed up and replaced with the latest version!${NC}"
 }
 
@@ -305,7 +305,7 @@ update_userjs () {
 
 remove_comments () {
   if [ $MINIFY = "true" ]; then
-    sed -n 1,8p user.js >> userjs_temps/no_comments.js # Add header
+    sed -n 1,8p user.js > userjs_temps/no_comments.js # Add header
     echo "******/" >> userjs_temps/no_comments.js # Add end of comment
     # Remove comments and empty lines
     sed -e 's/\s*\/\/ .*$//' -e 's|/\*|\n&|g;s|*/|&\n|g' -e '/\/\*/,/*\//d' -e '/^\s*$/d' -e '/^[[:space:]]*$/d' user.js >> userjs_temps/content.js

--- a/updater.sh
+++ b/updater.sh
@@ -39,12 +39,13 @@ ff_profile="$(dirname "${sfp}")"
 #########################
 
 usage() {                                             
-  echo -e ${BLUE}"\nUsage: $0 [-h] [-u] [-d] [-s] [-n] [-o OVERRIDE]\n"${NC} 1>&2  # Echo usage string to standard error
+  echo -e ${BLUE}"\nUsage: $0 [-h] [-u] [-d] [-s] [-n] [-b] [-o OVERRIDE]\n"${NC} 1>&2  # Echo usage string to standard error
   echo -e "Optional Arguments:"
   echo -e "\t-h,\t\t Show this help message and exit."
   echo -e "\t-u,\t\t Update updater.sh and execute silently.  Do not seek confirmation."
   echo -e "\t-d,\t\t Do not look for updates to updater.sh."
   echo -e "\t-s,\t\t Silently update user.js.  Do not seek confirmation."
+  echo -e "\t-b,\t\t Only keep one backup of each file."
   echo -e "\t-o OVERRIDE,\t Filename or path to overrides file (if different than user-overrides.js)."
   echo -e "\t-n,\t\t Do not append any overrides, evein if user-overrides.js exists."
   echo -e
@@ -62,6 +63,7 @@ legacy_argument () {
 UPDATE="check"                                          
 CONFIRM="yes"
 OVERRIDE="user-overrides.js"
+BACKUP="multiple"
 
 
 if [ $# != 0 ]; then
@@ -75,7 +77,7 @@ if [ $# != 0 ]; then
     UPDATE="yes"
     legacy_argument $1
   else
-    while getopts ":hudso:n" opt; do
+    while getopts ":hudso:nb" opt; do
       case $opt in 
         h)
           usage
@@ -94,6 +96,9 @@ if [ $# != 0 ]; then
           ;;
         n)
           OVERRIDE="none"
+          ;;
+        b)
+          BACKUP="single"
           ;;
         \?)
           echo -e ${RED}"\nInvalid option: -$OPTARG"${NC} >&2
@@ -154,6 +159,11 @@ download_file () {
 backup_file () {
   filename=$1
   mkdir -p userjs_backups
+  if [ $BACKUP = "single" ]; then
+    cd userjs_backups
+    find . -type f -name $filename\* -exec rm {} \;
+    cd ..
+  fi
   mv $filename "userjs_backups/${filename}.backup.$(date +"%Y-%m-%d_%H%M")"
   mv "userjs_temps/${filename}" $filename
   echo -e "Status: ${GREEN}${filename} has been backed up and replaced with the latest version!${NC}"

--- a/updater.sh
+++ b/updater.sh
@@ -267,7 +267,7 @@ update_userjs () {
   cp user.js "$bakname"
 
   mv "${newfile}" user.js
-  echo -e "Status: ${GREEN}${filename} has been backed up and replaced with the latest version!${NC}"
+  echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
 
   # apply overrides
   if [ "$SKIPOVERRIDE" = false ]; then
@@ -286,7 +286,13 @@ update_userjs () {
     remove_comments user.js $current_nocomments
 
     diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
-    diff -w -B -U 0 $past_nocomments $current_nocomments > "$diffname"
+    diff=$(diff -w -B -U 0 $past_nocomments $current_nocomments) 
+    if [ ! -z "$diff" ]; then
+      echo "$diff" > "$diffname"
+      echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
+    else
+      echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created."${NC}
+    fi
 
     rm $past_nocomments $current_nocomments $pastuserjs
   fi

--- a/updater.sh
+++ b/updater.sh
@@ -12,7 +12,6 @@
 #    Base variables     #
 #########################
 
-update_pref=${1:--ask}
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 BBLUE='\033[1;34m' 
@@ -47,6 +46,7 @@ usage() {
   echo -e "\t-s,\t\t Silently update user.js.  Do not seek confirmation."
   echo -e "\t-b,\t\t Only keep one backup of each file."
   echo -e "\t-o OVERRIDE,\t Filename or path to overrides file (if different than user-overrides.js)."
+  echo -e "\t\t\t If given a directory, all files inside will be appended recursively."
   echo -e "\t-n,\t\t Do not append any overrides, evein if user-overrides.js exists."
   echo -e
   exit 1
@@ -268,9 +268,17 @@ get_userjs_version () {
 update_userjs () {
   backup_file user.js
   if [ $OVERRIDE != "none" ]; then
-    if [ -e "$OVERRIDE" ]; then
+    if [ -f "$OVERRIDE" ]; then
       cat $OVERRIDE >> user.js
       echo -e "Status: ${GREEN}Your override customizations have been applied!${NC}"
+    elif [ -d "$OVERRIDE" ]; then
+        FILES=${OVERRIDE}/*
+        for f in $FILES
+        do
+          echo "" >> user.js
+          cat $f >> user.js
+        done
+        echo -e "Status: ${GREEN}Your override customizations have been applied!${NC}"
     else
       echo -e "${ORANGE}Warning: Could not find override file:${NC} ${OVERRIDE}"
       echo -e "You are using the default ghacks user.js file."

--- a/updater.sh
+++ b/updater.sh
@@ -6,7 +6,14 @@
 ## Author: Pat Johnson (@overdodactyl)
 ## Additional contributors: @earthlng, @ema-pe
 
-## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in check_for_update() )
+## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_updater() )
+
+readonly currdir=$(pwd)
+
+sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
+if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
+readonly SCRIPT_DIR="$(dirname "${sfp}")"
+
 
 #########################
 #    Base variables     #
@@ -36,11 +43,8 @@ PROFILE_PATH=false
 #########################
 
 set_wd () {
-  currdir=$(pwd)
   if [ "$PROFILE_PATH" = false ]; then
-    sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
-    if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
-    ff_profile="$(dirname "${sfp}")"
+    ff_profile="$SCRIPT_DIR"
   elif [ "$PROFILE_PATH" = "list" ]; then
     if [ "$(uname)" == "Darwin" ]; then
       firefox_dir=~/Library/Application\ Support/Firefox/Profiles/ 
@@ -59,7 +63,7 @@ set_wd () {
   else
     ff_profile="$PROFILE_PATH"
   fi
-    cd "$ff_profile"
+  cd "$ff_profile"
 }
 
 #########################

--- a/updater.sh
+++ b/updater.sh
@@ -47,7 +47,7 @@ set_wd () {
     elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
       firefox_dir=~/.mozilla/firefox/
     else
-      echo -e ${RED}"Error: Sorry, -l is not suppported for your OS"${NC}
+      echo -e ${RED}"Error: Sorry, -l is not supported for your OS"${NC}
       exit 1
     fi
     echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
@@ -106,7 +106,7 @@ legacy_argument () {
 }
 
 #########################
-#     File Handeling    #
+#     File Handling    #
 #########################
 
 # Download method priority: curl -> wget -> perl
@@ -333,7 +333,7 @@ create_diff () {
 
 if [ $# != 0 ]; then
   legacy_lc="$(echo $1 | tr '[A-Z]' '[a-z]')"
-  # Display usage if first arguement is -help or --help
+  # Display usage if first argument is -help or --help
   if [ $1 = "--help" ] || [ $1 = "-help" ]; then
     usage
   elif [ $legacy_lc = "-donotupdate" ]; then

--- a/updater.sh
+++ b/updater.sh
@@ -48,7 +48,10 @@ usage() {
   echo -e "\t-o OVERRIDE,\t Filename or path to overrides file (if different than user-overrides.js)."
   echo -e "\t\t\t If given a directory, all files inside will be appended recursively."
   echo -e "\t\t\t You can pass multiple files or directories by passing a comma separated list."
-  echo -e "\t\t\t\t IMPORTANT: do not add spaces.  Ex: -o file1.js,file2.js,dir1"
+  echo -e "\t\t\t\t Note: only files ending in the extension .js are appended"
+  echo -e "\t\t\t\t IMPORTANT: do not add spaces between files/paths.  Ex: -o file1.js,file2.js,dir1"
+  echo -e "\t\t\t\t IMPORTANT: if any files/paths include spaces, wrap the entire argument in quotes."
+  echo -e "\t\t\t\t\t Ex: -o \"override folder\" "
   echo -e "\t-n,\t\t Do not append any overrides, even if user-overrides.js exists."
   echo -e
   exit 1

--- a/updater.sh
+++ b/updater.sh
@@ -58,8 +58,7 @@ set_wd () {
       echo -e ${RED}"Error: Sorry, -l is not supported for your OS"${NC}
       exit 1
     fi
-    numdirs=("$firefox_dir"/*)
-    if [[ ${#numdirs[@]} == "1" ]]; then 
+    if [ $(find "$firefox_dir" -maxdepth 1 -type d | wc -l) == "2" ]; then
       ff_profile=$(ls -d "$firefox_dir"*)
     else 
       echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
@@ -84,8 +83,8 @@ usage() {
   echo -e "Optional Arguments:"
   echo -e "\t-h,\t\t Show this help message and exit."
   echo -e "\t-p PROFILE,\t Path to your Firefox profile (if different than the dir of this script)"
-  echo -e "\t-l, \t\t Choose your Firefox profile from a list"
   echo -e "\t\t\t IMPORTANT: if the path include spaces, wrap the entire argument in quotes."
+  echo -e "\t-l, \t\t Choose your Firefox profile from a list"
   echo -e "\t-u,\t\t Update updater.sh and execute silently.  Do not seek confirmation."
   echo -e "\t-d,\t\t Do not look for updates to updater.sh."
   echo -e "\t-s,\t\t Silently update user.js.  Do not seek confirmation."

--- a/updater.sh
+++ b/updater.sh
@@ -2,7 +2,7 @@
 
 ## ghacks-user.js updater for macOS and Linux
 
-## version: 1.6
+## version: 2.0
 ## Author: Pat Johnson (@overdodactyl)
 ## Additional contributors: @earthlng, @ema-pe
 
@@ -75,6 +75,7 @@ CONFIRM="yes"
 OVERRIDE="user-overrides.js"
 BACKUP="multiple"
 COMPARE=false
+SKIPOVERRIDE=false
 
 if [ $# != 0 ]; then
   legacy_lc="$(echo $1 | tr '[A-Z]' '[a-z]')"
@@ -103,7 +104,7 @@ if [ $# != 0 ]; then
           CONFIRM="no"                     
           ;;
         n)
-          OVERRIDE="none"
+          SKIPOVERRIDE=true
           ;;
         o)
           OVERRIDE=${OPTARG}
@@ -309,11 +310,12 @@ update_userjs () {
     cp user.js userjs_diffs/past_user.js
   fi
   backup_file user.js
-  if [ "$OVERRIDE" != "none" ]; then
-    while IFS=',' read -ra FILE; do
-      add_override "$FILE"
-    done <<< "$OVERRIDE"
+  if [ "$SKIPOVERRIDE" = true ]; then
+    return 0
   fi
+  while IFS=',' read -ra FILE; do
+    add_override "$FILE"
+  done <<< "$OVERRIDE"
 }
 
 remove_comments () {

--- a/updater.sh
+++ b/updater.sh
@@ -62,21 +62,22 @@ legacy_argument () {
   echo -e "Please view the new options using the -h argument."${NC}
 }
 
-# Arguement defaults
-UPDATE="check"                                          
+# Argument defaults
+UPDATE="check"
 CONFIRM="yes"
 OVERRIDE="user-overrides.js"
 BACKUP="multiple"
 MINIFY="false"
 
 if [ $# != 0 ]; then
+  legacy_lc="$(echo $1 | tr '[A-Z]' '[a-z]')"
   # Display usage if first arguement is -help or --help
   if [ $1 = "--help" ] || [ $1 = "-help" ]; then
     usage
-  elif [ $1 = "-donotupdate" ]; then
+  elif [ $legacy_lc = "-donotupdate" ]; then
     UPDATE="no"
     legacy_argument $1
-  elif [ $1 = "-update" ]; then
+  elif [ $legacy_lc = "-update" ]; then
     UPDATE="yes"
     legacy_argument $1
   else

--- a/updater.sh
+++ b/updater.sh
@@ -58,12 +58,19 @@ set_wd () {
       echo -e ${RED}"Error: Sorry, -l is not supported for your OS"${NC}
       exit 1
     fi
-    echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
-    ls -d "$firefox_dir"*
-    echo -e ${RED}"\nWhich profile would you like to update?"${NC}
-    read -p ""
-    echo -e ""
-    ff_profile=$REPLY
+    numdirs=("$firefox_dir"/*)
+    numdirs=${#numdirs[@]}
+    if [[ $numdirs == "1" ]]; then 
+      ff_profile=$(ls -d "$firefox_dir"*)
+    else 
+      echo "wrong"
+      echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
+      ls -d "$firefox_dir"*
+      echo -e ${RED}"\nWhich profile would you like to update?"${NC}
+      read -p ""
+      echo -e ""
+      ff_profile=$REPLY
+    fi
   else
     ff_profile="$PROFILE_PATH"
   fi
@@ -295,14 +302,14 @@ update_userjs () {
     remove_comments $pastuserjs $past_nocomments
     remove_comments user.js $current_nocomments
 
-      diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
-      diff=$(diff -w -B -U 0 $past_nocomments $current_nocomments) 
-      if [ ! -z "$diff" ]; then
-        echo "$diff" > "$diffname"
-        echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
-      else
-        echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created."${NC}
-      fi
+    diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
+    diff=$(diff -w -B -U 0 $past_nocomments $current_nocomments) 
+    if [ ! -z "$diff" ]; then
+      echo "$diff" > "$diffname"
+      echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
+    else
+      echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created."${NC}
+    fi
 
     rm $past_nocomments $current_nocomments $pastuserjs
   fi

--- a/updater.sh
+++ b/updater.sh
@@ -49,11 +49,12 @@ usage() {
   echo -e "\t-o OVERRIDE,\t Filename or path to overrides file (if different than user-overrides.js)."
   echo -e "\t\t\t If given a directory, all files inside will be appended recursively."
   echo -e "\t\t\t You can pass multiple files or directories by passing a comma separated list."
-  echo -e "\t\t\t\t Note: only files ending in the extension .js are appended"
+  echo -e "\t\t\t\t Note: If a directory is given, only files inside ending in the extension .js are appended"
   echo -e "\t\t\t\t IMPORTANT: do not add spaces between files/paths.  Ex: -o file1.js,file2.js,dir1"
   echo -e "\t\t\t\t IMPORTANT: if any files/paths include spaces, wrap the entire argument in quotes."
   echo -e "\t\t\t\t\t Ex: -o \"override folder\" "
   echo -e "\t-n,\t\t Do not append any overrides, even if user-overrides.js exists."
+  echo -e "\t-v,\t\t Open the resulting user.js file."
   echo -e
   echo -e "Deprecated Arguments (they still work for now):"
   echo -e "\t-donotupdate,\t Use instead -d"
@@ -76,6 +77,7 @@ OVERRIDE="user-overrides.js"
 BACKUP="multiple"
 COMPARE=false
 SKIPOVERRIDE=false
+VIEW=false
 
 if [ $# != 0 ]; then
   legacy_lc="$(echo $1 | tr '[A-Z]' '[a-z]')"
@@ -89,7 +91,7 @@ if [ $# != 0 ]; then
     UPDATE="yes"
     legacy_argument $1
   else
-    while getopts ":hudsno:bc " opt; do
+    while getopts ":hudsno:bcv" opt; do
       case $opt in 
         h)
           usage
@@ -115,6 +117,9 @@ if [ $# != 0 ]; then
         c)
           COMPARE=true
           ;;
+        v)
+          VIEW=true
+          ;;
         \?)
           echo -e ${RED}"\n Error! Invalid option: -$OPTARG"${NC} >&2
           usage
@@ -127,8 +132,6 @@ if [ $# != 0 ]; then
     done
   fi  
 fi
-
-echo $OVERRIDE
 
 
 #########################
@@ -337,6 +340,12 @@ create_diff () {
   fi
 }
 
+view_userjs () {
+  if [ "$VIEW" = true ]; then
+    open user.js
+  fi
+}
+
 
 #########################
 #        Execute        #
@@ -349,5 +358,6 @@ initiate
 update_updater
 confirmation && update_userjs
 create_diff
+view_userjs
 rm -rf userjs_temps
 cd "${currdir}"

--- a/updater.sh
+++ b/updater.sh
@@ -59,7 +59,7 @@ legacy_argument () {
   arg=$1
   echo -e ${ORANGE}"\nWarning: command line arguments have changed."
   echo -e "${arg} has been deprecated and may not work in the future.\n"
-  echo -e "Please view the new options using the --help argument."${NC}
+  echo -e "Please view the new options using the -h argument."${NC}
 }
 
 # Arguement defaults
@@ -301,8 +301,9 @@ remove_comments () {
     sed -n 1,8p user.js >> userjs_temps/no_comments.js # Add header
     echo "******/" >> userjs_temps/no_comments.js # Add end of comment
     # Remove comments and empty lines
-    sed -e 's|/\*|\n&|g;s|*/|&\n|g' -e '/\/\*/,/*\//d' -e 's/\s*\/\/ .*$//' -e '/^\s*$/d' -e '/^[[:space:]]*$/d' user.js >> userjs_temps/content.js
+    sed -e 's/\s*\/\/ .*$//' -e 's|/\*|\n&|g;s|*/|&\n|g' -e '/\/\*/,/*\//d' -e '/^\s*$/d' -e '/^[[:space:]]*$/d' user.js >> userjs_temps/content.js
     cat userjs_temps/content.js >> userjs_temps/no_comments.js
+    # cat user.js >> userjs_temps/no_comments.js
     mv userjs_temps/no_comments.js user.js
   else
     return 0

--- a/updater.sh
+++ b/updater.sh
@@ -54,7 +54,7 @@ usage() {
   echo -e "\t\t\t\t\t Ex: -o \"override folder\" "
   echo -e "\t-n,\t\t Do not append any overrides, even if user-overrides.js exists."
   echo -e
-  echo -e "Deprecated Arguments:"
+  echo -e "Deprecated Arguments (they still work for now):"
   echo -e "\t-donotupdate,\t Use instead -d"
   echo -e "\t-update,\t Use instead -u"
   echo -e
@@ -86,7 +86,7 @@ if [ $# != 0 ]; then
     UPDATE="yes"
     legacy_argument $1
   else
-    while getopts ":hudso:nb" opt; do
+    while getopts ":hudsno:b" opt; do
       case $opt in 
         h)
           usage
@@ -100,11 +100,11 @@ if [ $# != 0 ]; then
         s)
           CONFIRM="no"                     
           ;;
-        o)
-          OVERRIDE=${OPTARG}
-          ;;
         n)
           OVERRIDE="none"
+          ;;
+        o)
+          OVERRIDE=${OPTARG}
           ;;
         b)
           BACKUP="single"
@@ -277,15 +277,13 @@ get_userjs_version () {
 add_override () {
   input=$1
   if [ -f "$input" ]; then
-    if [[ "$input" == *.js ]]; then
-      echo "" >> user.js
-      cat "$input" >> user.js
-      echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
-    fi
+    echo "" >> user.js
+    cat "$input" >> user.js
+    echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
   elif [ -d "$input" ]; then
     FSAVEIFS=$IFS
     IFS=$(echo -en "\n\b") # Set IFS
-    FILES="${input}"/*
+    FILES="${input}"/*.js
     for f in $FILES
     do
       add_override "$f"

--- a/updater.sh
+++ b/updater.sh
@@ -11,6 +11,7 @@
 #########################
 #    Base variables     #
 #########################
+
 update_pref=${1:--ask}
 RED='\033[0;31m'
 BLUE='\033[0;34m'
@@ -34,12 +35,12 @@ if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
 ff_profile="$(dirname "${sfp}")"
 
 #########################
-#      Arguements       #
+#      Arguments       #
 #########################
 
 usage() {                                             
-  echo -e ${BLUE}"\nUsage: $0 [ -u UPDATE ] [ -t CONFIRM ]\n"${NC} 1>&2  # Echo usage string to standard error
-  echo -e "Optional Arguements:"
+  echo -e ${BLUE}"\nUsage: $0 [ -u UPDATE ] [ -c CONFIRM ] [ -o OVERRIDE]\n"${NC} 1>&2  # Echo usage string to standard error
+  echo -e "Optional Arguments:"
   echo -e "\t -u UPDATE"
   echo -e "\t\t check (default):  Check for availabe updates to updater.sh and confirm installation/execution"
   echo -e "\t\t yes:              Check for availabe updates and install/execute silently"
@@ -49,42 +50,55 @@ usage() {
   echo -e "\t\t no:               Silently update user.js"
   echo -e "\t -o OVERRIDE"
   echo -e "\t\t filename:         Filename or path to append to user.js (default: user-overrides.js)"
-  echo -e "\t\t none:             Do not append any overrides"
+  echo -e "\t\t none:             Do not append any overrides, evein if user-overrides.js exists"
   echo -e
   exit 1
 }
 
+legacy_argument () {
+  arg=$1
+  echo -e ${ORANGE}"\nWarning: command line arguments have changed."
+  echo -e "${arg} has been deprecated and may not work in the future.\n"
+  echo -e "Please view the new options using the --help argument."${NC}
+}
+
+# Arguement defaults
+  UPDATE="check"                                          
+  CONFIRM="yes"
+  OVERRIDE="user-overrides.js" 
+
 # Display usage if first arguement is -help or --help
 if [ $1 = "--help" ] || [ $1 = "-help" ]; then
   usage
+elif [ $1 = "-donotupdate" ]; then
+  UPDATE="no"
+  legacy_argument $1
+elif [ $1 = "-update" ]; then
+  UPDATE="yes"
+  legacy_argument $1
+else
+  # Get user set arguements 
+  while getopts "u:c:o:" options; do
+    case "${options}" in                          
+      u)
+        UPDATE=${OPTARG}
+        if [ $CONFIRM != "check" ] && [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
+          echo -e ${RED}"\nError: -u must be one of [check, yes, no]"${NC}
+          usage
+        fi 
+        ;;
+      c)
+        CONFIRM=${OPTARG}
+        if [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
+          echo -e ${RED}"\nError: -c must be one of [yes, no]"${NC}
+          usage
+        fi                          
+        ;;
+      o)
+        OVERRIDE=${OPTARG}
+    esac
+  done
 fi
-
-# Arguement defaults
-UPDATE="check"                                          
-CONFIRM="yes"
-OVERRIDE="user-overrides.js" 
-
-# Get user set arguements 
-while getopts "u:c:o:" options; do
-  case "${options}" in                          
-    u)
-      UPDATE=${OPTARG}
-      if [ $CONFIRM != "check" ] && [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
-        echo -e ${RED}"\nError: -u must be one of [check, yes, no]"${NC}
-        usage
-      fi 
-      ;;
-    c)
-      CONFIRM=${OPTARG}
-      if [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
-        echo -e ${RED}"\nError: -c must be one of [yes, no]"${NC}
-        usage
-      fi                          
-      ;;
-    o)
-      OVERRIDE=${OPTARG}
-  esac
-done
 
 
 

--- a/updater.sh
+++ b/updater.sh
@@ -39,18 +39,14 @@ ff_profile="$(dirname "${sfp}")"
 #########################
 
 usage() {                                             
-  echo -e ${BLUE}"\nUsage: $0 [ -u UPDATE ] [ -c CONFIRM ] [ -o OVERRIDE]\n"${NC} 1>&2  # Echo usage string to standard error
+  echo -e ${BLUE}"\nUsage: $0 [-h] [-u] [-d] [-s] [-n] [-o OVERRIDE]\n"${NC} 1>&2  # Echo usage string to standard error
   echo -e "Optional Arguments:"
-  echo -e "\t -u UPDATE"
-  echo -e "\t\t check (default):  Check for availabe updates to updater.sh and confirm installation/execution"
-  echo -e "\t\t yes:              Check for availabe updates and install/execute silently"
-  echo -e "\t\t no:               Do not look for updates to updater.sh"
-  echo -e "\t -c CONFIRM"
-  echo -e "\t\t yes (default):    Ask for confirmation to update user.js after viewing versions"
-  echo -e "\t\t no:               Silently update user.js"
-  echo -e "\t -o OVERRIDE"
-  echo -e "\t\t filename:         Filename or path to append to user.js (default: user-overrides.js)"
-  echo -e "\t\t none:             Do not append any overrides, evein if user-overrides.js exists"
+  echo -e "\t-h,\t\t Show this help message and exit."
+  echo -e "\t-u,\t\t Update updater.sh and execute silently.  Do not seek confirmation."
+  echo -e "\t-d,\t\t Do not look for updates to updater.sh."
+  echo -e "\t-s,\t\t Silently update user.js.  Do not seek confirmation."
+  echo -e "\t-o OVERRIDE,\t Filename or path to overrides file (if different than user-overrides.js)."
+  echo -e "\t-n,\t\t Do not append any overrides, evein if user-overrides.js exists."
   echo -e
   exit 1
 }
@@ -63,42 +59,51 @@ legacy_argument () {
 }
 
 # Arguement defaults
-  UPDATE="check"                                          
-  CONFIRM="yes"
-  OVERRIDE="user-overrides.js" 
+UPDATE="check"                                          
+CONFIRM="yes"
+OVERRIDE="user-overrides.js"
 
-# Display usage if first arguement is -help or --help
-if [ $1 = "--help" ] || [ $1 = "-help" ]; then
-  usage
-elif [ $1 = "-donotupdate" ]; then
-  UPDATE="no"
-  legacy_argument $1
-elif [ $1 = "-update" ]; then
-  UPDATE="yes"
-  legacy_argument $1
-else
-  # Get user set arguements 
-  while getopts "u:c:o:" options; do
-    case "${options}" in                          
-      u)
-        UPDATE=${OPTARG}
-        if [ $CONFIRM != "check" ] && [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
-          echo -e ${RED}"\nError: -u must be one of [check, yes, no]"${NC}
+
+if [ $# != 0 ]; then
+  # Display usage if first arguement is -help or --help
+  if [ $1 = "--help" ] || [ $1 = "-help" ]; then
+    usage
+  elif [ $1 = "-donotupdate" ]; then
+    UPDATE="no"
+    legacy_argument $1
+  elif [ $1 = "-update" ]; then
+    UPDATE="yes"
+    legacy_argument $1
+  else
+    while getopts ":hudso:n" opt; do
+      case $opt in 
+        h)
           usage
-        fi 
-        ;;
-      c)
-        CONFIRM=${OPTARG}
-        if [ $CONFIRM != "yes" ] && [ $CONFIRM != "no" ]; then
-          echo -e ${RED}"\nError: -c must be one of [yes, no]"${NC}
+          ;;                         
+        u)
+          UPDATE="yes"
+          ;;
+        d)
+          UPDATE="no"
+          ;;
+        s)
+          CONFIRM="no"                     
+          ;;
+        o)
+          OVERRIDE=${OPTARG}
+          ;;
+        n)
+          OVERRIDE="none"
+          ;;
+        \?)
+          echo -e ${RED}"\nInvalid option: -$OPTARG"${NC} >&2
           usage
-        fi                          
-        ;;
-      o)
-        OVERRIDE=${OPTARG}
-    esac
-  done
+          ;;
+      esac
+    done
+  fi  
 fi
+
 
 
 
@@ -234,7 +239,7 @@ update_updater () {
   # Backup current updater, execute latest version
   backup_file updater.sh
   chmod +x updater.sh
-  ./updater.sh -u no
+  ./updater.sh "$@"
   exit 1
 }
 

--- a/updater.sh
+++ b/updater.sh
@@ -314,7 +314,7 @@ update_userjs () {
 remove_comments () {
   from_file=$1 
   to_file=$2
-  sed -e 's/^[[:space:]]*\/\/.*$//' -e '/^\/\*/,/\*\//d' -e '/^[[:space:]]*$/d' -e 's/);[[:space:]]\/\/.*/);/' $from_file > $to_file 
+  sed -e 's/^[[:space:]]*\/\/.*$//' -e '/^\/\*/,/\*\//d' -e '/^[[:space:]]*$/d' -e 's/);[[:space:]]*\/\/.*/);/' $from_file > $to_file 
  }
 
 create_diff () {

--- a/updater.sh
+++ b/updater.sh
@@ -59,11 +59,9 @@ set_wd () {
       exit 1
     fi
     numdirs=("$firefox_dir"/*)
-    numdirs=${#numdirs[@]}
-    if [[ $numdirs == "1" ]]; then 
+    if [[ ${#numdirs[@]} == "1" ]]; then 
       ff_profile=$(ls -d "$firefox_dir"*)
     else 
-      echo "wrong"
       echo -e ${GREEN}"The following profiles were found:\n"${ORANGE}
       ls -d "$firefox_dir"*
       echo -e ${RED}"\nWhich profile would you like to update?"${NC}

--- a/updater.sh
+++ b/updater.sh
@@ -279,12 +279,14 @@ add_override () {
     cat "$input" >> user.js
     echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
   elif [ -d "$input" ]; then
-    FILES="${input}/*"
+    FSAVEIFS=$IFS
+    IFS=$(echo -en "\n\b") # Set IFS
+    FILES="${input}"/*
     for f in $FILES
-    do 
-      echo "$f"
+    do
       add_override "$f"
     done
+    IFS=$SAVEIFS # restore $IFS
   else
     echo -e "${ORANGE}Warning: Could not find override file:${NC} ${input}"
   fi

--- a/updater.sh
+++ b/updater.sh
@@ -141,6 +141,16 @@ download_file () {
   $dlcmd "${url}" &>/dev/null && echo "$tf" || echo "" # return the temp-filename (or empty string on error)
 }
 
+open_file () { #expects one argument: file_path
+  if [ "$(uname)" == "Darwin" ]; then
+    open "$1"
+  elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    xdg-open "$1"
+  else
+    echo -e ${RED}"Error: Sorry, opening files is not supported for your OS."${NC}
+  fi
+}
+
 
 show_banner () {
   echo -e
@@ -285,20 +295,20 @@ update_userjs () {
     remove_comments $pastuserjs $past_nocomments
     remove_comments user.js $current_nocomments
 
-    diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
-    diff=$(diff -w -B -U 0 $past_nocomments $current_nocomments) 
-    if [ ! -z "$diff" ]; then
-      echo "$diff" > "$diffname"
-      echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
-    else
-      echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created."${NC}
-    fi
+      diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
+      diff=$(diff -w -B -U 0 $past_nocomments $current_nocomments) 
+      if [ ! -z "$diff" ]; then
+        echo "$diff" > "$diffname"
+        echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
+      else
+        echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created."${NC}
+      fi
 
     rm $past_nocomments $current_nocomments $pastuserjs
   fi
 
   if [ "$VIEW" = true ]; then
-    open user.js
+    open_file "${PWD}/user.js"
   fi
 
 }
@@ -358,7 +368,7 @@ if [ $# != 0 ]; then
           tfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')
           mv $tfile "${tfile}.js"
           echo -e ${ORANGE}"Warning: user.js was saved to temporary file ${tfile}.js"${NC}
-          open "${tfile}.js"
+          open_file "${tfile}.js"
           exit 1
           ;;
         \?)


### PR DESCRIPTION
This PR focuses on making better use of command line arguments for `updater.sh` using `getopts` as well as adding additional options.

I deleted some past comments and will just update this one to prevent spamming people's emails. 

Result of `./updater.sh -h`:

```txt
Usage: ./updater.sh [-h] [-u] [-d] [-s] [-n] [-b] [-m] [-o OVERRIDE]

Optional Arguments:
	-h,		 Show this help message and exit.
	-u,		 Update updater.sh and execute silently.  Do not seek confirmation.
	-d,		 Do not look for updates to updater.sh.
	-s,		 Silently update user.js.  Do not seek confirmation.
	-b,		 Only keep one backup of each file.
	-o OVERRIDE,	 Filename or path to overrides file (if different than user-overrides.js).
			 If given a directory, all files inside will be appended recursively.
			 You can pass multiple files or directories by passing a comma separated list.
				 IMPORTANT: do not add spaces.  Ex: -o file1.js,file2.js,dir1
	-n,		 Do not append any overrides, even if user-overrides.js exists.
	-m,		 Minify resulting user.js file. i.e. remove all comments except header.
```

Args can be written separately or together. Examples:

```txt
./updater.sh -sdm
./updater.sh -sd -o relaxed.js
./updater.sh -s -d
```


Deprecated arguments will still work, but a message like the following will show up in yellow:

```
Warning: command line arguments have changed.
-donotupdate has been deprecated and may not work in the future.

Please view the new options using the -h argument.
```

This should prevent breakage for people who are used to the current form, but could help transition to the more flexible version in this PR.  