### PR TITLE
fix profile check

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -2,7 +2,7 @@
 
 ## ghacks-user.js updater for macOS and Linux
 
-## version: 2.2
+## version: 2.3
 ## Author: Pat Johnson (@overdodactyl)
 ## Additional contributors: @earthlng, @ema-pe, @claustromaniac
 
@@ -147,7 +147,7 @@ readIniFile () { # expects one argument: absolute path of profiles.ini
     echo -e "\n"
     if [[ $REPLY =~ ^(0|[1-9][0-9]*)$ ]]; then
       grep '^\[Profile'${REPLY} -A 4 "$inifile" | grep -v '^\[Profile'${REPLY} > $tfile
-      if [ !$? ]; then
+      if [[ "$?" != "0" ]]; then
         echo "Profile${REPLY} does not exist!" && exit 1
       fi
     else


### PR DESCRIPTION
I must not have tested after this change was made:

https://github.com/ghacksuserjs/ghacks-user.js/pull/554#discussion_r236102460

With how it is now, macOS never detects a profile, so I reverted it back and bumped the version number.