### PR TITLE
updater.sh: add -e option for ESR users

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -307,7 +307,7 @@ update_userjs () {
   echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
 
   if [ "$ESR" = true ]; then
-    sed -i.bak 's/\/\* \(ESR[0-9][0-9]\.x still uses all.*\)/\/\/ \1/' user.js
+    sed -i.bak 's/\/\* \(ESR[0-9]\{2,\}\.x still uses all.*\)/\/\/ \1/' user.js
     echo -e "Status: ${GREEN}ESR related preferences have been activated!${NC}"
   fi
 

--- a/updater.sh
+++ b/updater.sh
@@ -307,7 +307,7 @@ update_userjs () {
   echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
 
   if [ "$ESR" = true ]; then
-    sed -i.bak 's/\/\* \(ESR[0-9]\{2,\}\.x still uses all.*\)/\/\/ \1/' user.js
+    sed -e 's/\/\* \(ESR[0-9]\{2,\}\.x still uses all.*\)/\/\/ \1/' user.js > user.js.tmp && mv user.js.tmp user.js
     echo -e "Status: ${GREEN}ESR related preferences have been activated!${NC}"
   fi
 


### PR DESCRIPTION
(This PR should be looked into after #564)

I'm not sure if we want to include this or not, but I thought it might make a nice addition...

From the wiki:

>Several sections in the user.js have one-char switches to enable/disable the entire section (e.g. deprecated items by ESR version). You will have to remember to do these manually if required.

I've added `-e`, which activates the ESR prefs when used.  It matches based on `/* ESR##.x still uses all`, which I think should be specific enough...that phrase would have to stay consistent in future versions of the `user.js` though (I did a quick glance through some old versions and it seems to have stuck around).




