### PR TITLE
move 0370 to 0105b

### DIFF
--- a/user.js
+++ b/user.js
@@ -105,13 +105,15 @@ user_pref("browser.newtab.preload", false);
 user_pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.telemetry.ping.endpoint", "");
-/* 0105b: disable AS Snippets ***/
+/* 0105b: disable AS Snippets
+ * [1] https://abouthome-snippets-service.readthedocs.io/ ***/
 user_pref("browser.newtabpage.activity-stream.disableSnippets", true);
 user_pref("browser.newtabpage.activity-stream.feeds.snippets", false); // has setting (see 0105)
+user_pref("browser.aboutHomeSnippets.updateUrl", "");
 /* 0105c: disable AS Top Stories, Pocket-based and/or sponsored content ***/
-user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false); // has setting (see 0105)
 user_pref("browser.newtabpage.activity-stream.section.highlights.includePocket", false); // has setting (see 0105)
-user_pref("browser.newtabpage.activity-stream.showSponsored", false);
+user_pref("browser.newtabpage.activity-stream.showSponsored", false); // has setting (see 0105)
 /* 0105d: disable AS recent Highlights in the Library [FF57+] ***/
    // user_pref("browser.library.activity-stream.enabled", false);
 /* 0110: start Firefox in PB (Private Browsing) mode
@@ -234,9 +236,6 @@ user_pref("breakpad.reportURL", "");
 user_pref("browser.tabs.crashReporting.sendReport", false); // [FF44+]
 user_pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+]
 user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false); // [FF58+]
-/* 0370: disable "Snippets" (Mozilla content shown on about:home screen)
- * [1] https://wiki.mozilla.org/Firefox/Projects/Firefox_Start/Snippet_Service ***/
-user_pref("browser.aboutHomeSnippets.updateUrl", "data:,");
 /* 0380: disable Browser Error Reporter [FF60+]
  * [1] https://support.mozilla.org/en-US/kb/firefox-nightly-error-collection
  * [2] https://firefox-source-docs.mozilla.org/browser/browser/BrowserErrorReporter.html ***/

--- a/user.js
+++ b/user.js
@@ -106,6 +106,7 @@ user_pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.telemetry.ping.endpoint", "");
 /* 0105b: disable AS Snippets
+ * Runs code received from a server (aka Remote Code Execution) and sends information back to a metrics server
  * [1] https://abouthome-snippets-service.readthedocs.io/ ***/
 user_pref("browser.newtabpage.activity-stream.disableSnippets", true);
 user_pref("browser.newtabpage.activity-stream.feeds.snippets", false); // has setting (see 0105)


### PR DESCRIPTION
The link we had in 0370 is not very useful for end users.
https://abouthome-snippets-service.readthedocs.io/ is better

I did some digging into what exactly snippets are and how it works ...

Snippets = information about mozilla and firefox, like tips + tricks and things they want to highlight or advertise, etc. (~4MB of data with CSS, HTML + JS)
If you want to see the data, load [this](https://snippets.cdn.mozilla.net/5/Firefox/63.0/20181018182531/WINNT_x86_64-msvc/en-US/release/Windows_NT%206.1/default/default/) and look at the response.

"Updates from Mozilla and Firefox", as it says in the UI, doesn't sound that bad but it includes [metrics](https://abouthome-snippets-service.readthedocs.io/en/latest/data_collection.html#metrics), geolocation stuff and runs JS code received from a server (AKA remote code execution).

When I saw that it allows RCE I tried to inject code via the URL pref but "data" URIs don't work anymore because Activity Stream is now protected with a CSP.

Should we add something like `Runs code received from a server (aka Remote Code Execution) and sends information back to a metrics server`? Because "Updates from Mozilla and Firefox" makes it sound kind of tempting and a lot less shitty than it really is, IMHO.

ps: do we really want all those `// has setting` ?