### PR TITLE
FF65 removals [DRAFT]

### DIFF
--- a/user.js
+++ b/user.js
@@ -361,8 +361,6 @@ user_pref("browser.safebrowsing.provider.google4.dataSharingURL", "");
  * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1170190,1141814 ***/
    // user_pref("privacy.trackingprotection.annotate_channels", false);
    // user_pref("privacy.trackingprotection.lower_network_priority", false);
-/* 0426: enforce Content Blocking (required to block cookies) [FF63+] ***/
-user_pref("browser.contentblocking.enabled", true); // [DEFAULT: true]
 
 /*** [SECTION 0500]: SYSTEM ADD-ONS / EXPERIMENTS
      System Add-ons are a method for shipping extensions, considered to be
@@ -567,13 +565,9 @@ user_pref("browser.urlbar.usepreloadedtopurls.enabled", false);
 /* 0810: disable location bar making speculative connections [FF56+]
  * [1] https://bugzilla.mozilla.org/1348275 ***/
 user_pref("browser.urlbar.speculativeConnect.enabled", false);
-/* 0850a: disable location bar autocomplete and suggestion types
- * If you enforce any of the suggestion types, you MUST enforce 'autocomplete'
- *   - If *ALL* of the suggestion types are false, 'autocomplete' must also be false
- *   - If *ANY* of the suggestion types are true, 'autocomplete' must also be true
+/* 0850a: disable location bar suggestion types
  * [SETUP-CHROME] If all three suggestion types are false, search engine keywords are disabled
  * [SETTING] Privacy & Security>Address Bar>When using the address bar, suggest ***/
-user_pref("browser.urlbar.autocomplete.enabled", false);
 user_pref("browser.urlbar.suggest.history", false);
 user_pref("browser.urlbar.suggest.bookmark", false);
 user_pref("browser.urlbar.suggest.openpage", false);
@@ -643,9 +637,6 @@ user_pref("signon.storeWhenAutocompleteOff", true); // [DEFAULT: true]
 /* 0907: display warnings for logins on non-secure (non HTTPS) pages
  * [1] https://bugzilla.mozilla.org/1217156 ***/
 user_pref("security.insecure_password.ui.enabled", true);
-/* 0908: remove user & password info when attempting to fix an entered URL (i.e. 0802 is true)
- * e.g. //user:password@foo -> //user@(prefix)foo(suffix) NOT //user:password@(prefix)foo(suffix) ***/
-user_pref("browser.fixup.hide_user_pass", true);
 /* 0909: disable formless login capture for Password Manager [FF51+] ***/
 user_pref("signon.formlessCapture.enabled", false);
 /* 0910: disable autofilling saved passwords on HTTP pages and show warning [FF52+]
@@ -2231,6 +2222,18 @@ user_pref("devtools.webide.adbAddonURL", "");
    // [1] https://developer.mozilla.org/docs/Web/API/SecurityPolicyViolationEvent
    // [-] https://bugzilla.mozilla.org/1488165
 user_pref("security.csp.enable_violation_events", false);
+// * * * /
+// FF65
+// 0850a: disable location bar autocomplete and suggestion types
+   // If you enforce any of the suggestion types, you MUST enforce 'autocomplete'
+   //   - If *ALL* of the suggestion types are false, 'autocomplete' must also be false
+   //   - If *ANY* of the suggestion types are true, 'autocomplete' must also be true
+   // [-] https://bugzilla.mozilla.org/1502392
+user_pref("browser.urlbar.autocomplete.enabled", false);
+// 0908: remove user & password info when attempting to fix an entered URL (i.e. 0802 is true)
+   // e.g. //user:password@foo -> //user@(prefix)foo(suffix) NOT //user:password@(prefix)foo(suffix)
+   // [-] https://bugzilla.mozilla.org/1510580
+user_pref("browser.fixup.hide_user_pass", true); // [DEFAULT: true]
 // * * * /
 // ***/
 


### PR DESCRIPTION
do we need to keep the info for "autocomplete" under 9999?

not sure what to do with app.update.auto, maybe kind of a tag behind the pref, like `// FF65+: non-Windows only` or a line saying something like "In FF65+ on Windows this setting is now stored in a file and the pref was removed"