### PR TITLE
location bar changes

### DIFF
--- a/user.js
+++ b/user.js
@@ -585,7 +585,7 @@ user_pref("browser.urlbar.speculativeConnect.enabled", false);
 user_pref("browser.urlbar.autoFill", false);
 /* 0850e: disable location bar one-off searches [FF51+]
  * [1] https://www.ghacks.net/2016/08/09/firefox-one-off-searches-address-bar/ ***/
-user_pref("browser.urlbar.oneOffSearches", false);
+   // user_pref("browser.urlbar.oneOffSearches", false);
 /* 0850f: disable location bar suggesting local search history [FF57+]
  * [1] https://bugzilla.mozilla.org/1181644 ***/
 user_pref("browser.urlbar.maxHistoricalSearchSuggestions", 0);

--- a/user.js
+++ b/user.js
@@ -516,10 +516,10 @@ user_pref("network.file.disable_unc_paths", true); // [HIDDEN PREF]
 user_pref("network.gio.supported-protocols", ""); // [HIDDEN PREF]
 
 /*** [SECTION 0800]: LOCATION BAR / SEARCH BAR / SUGGESTIONS / HISTORY / FORMS [SETUP-CHROME]
-     If you are in a private environment (no unwanted eyeballs) and your device is private
-     (restricted access), and the device is secure when unattended (locked, encrypted, forensic
-     hardened), then items 0850 and above can be relaxed in return for more convenience and
-     functionality. Likewise, you may want to check the items cleared on shutdown in section 2800.
+     Change items 0850 and above to suit for privacy vs convenience and functionality. Consider
+     your environment (no unwanted eyeballs), your device (restricted access), your device's
+     unattended state (locked, encrypted, forensic hardened). Likewise, you may want to check
+     the items cleared on shutdown in section 2800.
      [NOTE] The urlbar is also commonly referred to as the location bar and address bar
      #Required reading [#] https://xkcd.com/538/
 ***/
@@ -569,9 +569,9 @@ user_pref("browser.urlbar.speculativeConnect.enabled", false);
 /* 0850a: disable location bar suggestion types
  * [SETUP-CHROME] If all three suggestion types are false, search engine keywords are disabled
  * [SETTING] Privacy & Security>Address Bar>When using the address bar, suggest ***/
-user_pref("browser.urlbar.suggest.history", false);
-user_pref("browser.urlbar.suggest.bookmark", false);
-user_pref("browser.urlbar.suggest.openpage", false);
+   // user_pref("browser.urlbar.suggest.history", false);
+   // user_pref("browser.urlbar.suggest.bookmark", false);
+   // user_pref("browser.urlbar.suggest.openpage", false);
 /* 0850c: disable location bar dropdown
  * This value controls the total number of entries to appear in the location bar dropdown
  * [NOTE] Items (bookmarks/history/openpages) with a high "frecency"/"bonus" will always


### PR DESCRIPTION
@earthlng . now that location bar autocomplete is gone, users will have to resort to css to stop the dropdown. So I see no point anymore in disabling all the suggestion types - because otherwise all you get is a single line blue dropdown.

These three items, 850a, are also on the list in #605 as the ones most often changed - small sample, but seems to be a pattern there. Note: I'm not concerned about any tags right now, the 605 issue can still address that later down the track

This should also solves search engine keywords, right?

What other items should we make inactive here? Which one is the one that shows your search engines as icons on the bottom of the dropdown - that can be make inactive IMO