### PR TITLE
0707: clean up DoH

### DIFF
--- a/user.js
+++ b/user.js
@@ -501,7 +501,7 @@ user_pref("network.proxy.socks_remote_dns", true);
  * CVE-2017-5384: Information disclosure via Proxy Auto-Config (PAC)
  * [1] https://bugzilla.mozilla.org/1255474 ***/
 user_pref("network.proxy.autoconfig_url.include_path", false); // [DEFAULT: false]
-/* 0707: disable (or setup) DNS-over-HTTPS (DoH) [FF60+]
+/* 0707: disable DNS-over-HTTPS (DoH) [FF60+]
  * TRR = Trusted Recursive Resolver
  * .mode: 0=off, 1=race, 2=TRR first, 3=TRR only, 4=race for stats but always use native result
  * To use a custom URI, use the Connection Settings panel, as it involves multiple prefs

--- a/user.js
+++ b/user.js
@@ -504,12 +504,12 @@ user_pref("network.proxy.autoconfig_url.include_path", false); // [DEFAULT: fals
 /* 0707: disable (or setup) DNS-over-HTTPS (DoH) [FF60+]
  * TRR = Trusted Recursive Resolver
  * .mode: 0=off, 1=race, 2=TRR first, 3=TRR only, 4=race for stats but always use native result
+ * To use a custom URI, use the Connection Settings panel, as it involves multiple prefs
  * [WARNING] DoH bypasses hosts and gives info to yet another party (e.g. Cloudflare)
+ * [SETTING] General>Network Settings>Settings>Enable DNS over HTTPS
  * [1] https://www.ghacks.net/2018/04/02/configure-dns-over-https-in-firefox/
  * [2] https://hacks.mozilla.org/2018/05/a-cartoon-intro-to-dns-over-https/ ***/
    // user_pref("network.trr.mode", 0);
-   // user_pref("network.trr.bootstrapAddress", "");
-   // user_pref("network.trr.uri", "");
 /* 0708: disable FTP [FF60+]
  * [1] https://www.ghacks.net/2018/02/20/firefox-60-with-new-preference-to-disable-ftp/ ***/
    // user_pref("network.ftp.enabled", false);


### PR DESCRIPTION
- remove network.trr.bootstrapAddress = default blank anyway
- remove network.trr.uri - this is mozilla's default value. Unfortunately, that value is hard-coded in FF65+ into the UI settings as an option to use the default URI, so changing this could be misleading
- In FF65 there is now a custom URI field in the UI settings, and that's what users should be using - but it actually controls two prefs if you check to use custom - see https://github.com/ghacksuserjs/ghacks-user.js/issues/610#issuecomment-460169782

I am not interested in maintaining how this UI works (and it could change). The single pref left above is all that is needed to turns it on or off, that's all I care about. I've added the [SETTING] info and that's where people can do their shit. That's good enough for me