### PR TITLE
updater.bat -ESR option

### DIFF
--- a/updater.bat
+++ b/updater.bat
@@ -3,10 +3,10 @@ TITLE ghacks user.js updater
 
 REM ## ghacks-user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 4.6
+REM ## version: 4.8
 REM ## instructions: https://github.com/ghacksuserjs/ghacks-user.js/wiki/3.3-Updater-Scripts
 
-SET v=4.7
+SET v=4.8
 
 VERIFY ON
 CD /D "%~dp0"


### PR DESCRIPTION
Closes #741

### Summary:
Adds an `-ESR` parameter that, after the `user.js` is downloaded (as `user.js.new`), replaces this line:
```js
/* ESR60.x still uses all the following prefs
```
with this:
```js
// ESR60.x still uses all the following prefs
```
That's all.