### PR TITLE
2701: cookies default

### DIFF
--- a/user.js
+++ b/user.js
@@ -1248,12 +1248,12 @@ user_pref("security.dialog_enable_delay", 700);
 ***/
 user_pref("_user.js.parrot", "2700 syntax error: the parrot's joined the bleedin' choir invisible!");
 /* 2701: disable 3rd-party cookies and site-data [SETUP-WEB]
- * 0=Accept cookies and site data (default), 1=(Block) All third-party cookies, 2=(Block) All cookies,
+ * 0=Accept cookies and site data, 1=(Block) All third-party cookies, 2=(Block) All cookies,
  * 3=(Block) Cookies from unvisited sites, 4=(Block) Third-party trackers (FF63+)
  * [NOTE] Value 4 is tied to the Tracking Protection lists
  * [NOTE] You can set exceptions under site permissions or use an extension
  * [SETTING] Privacy & Security>Content Blocking>Custom>Choose what to block>Cookies ***/
-user_pref("network.cookie.cookieBehavior", 1);
+user_pref("network.cookie.cookieBehavior", 1); // [DEFAULT: 4 in FF69+]
 /* 2702: set third-party cookies (i.e ALL) (if enabled, see 2701) to session-only
    and (FF58+) set third-party non-secure (i.e HTTP) cookies to session-only
    [NOTE] .sessionOnly overrides .nonsecureSessionOnly except when .sessionOnly=false and


### PR DESCRIPTION
@earthlng : is this OK?
- sticking the default at the end of the pref line
- I don't quite like the  extra line about TP: it implies the value must be 4 in order to use TP: which is not the case e.g exceptions? And TP is not just cookies, it's also JS (crypto, fingerprint: not 100% sure how it works: I think it just blocks the domains). Or am I overthinking this?