### PR TITLE
1201 update

### DIFF
--- a/user.js
+++ b/user.js
@@ -639,15 +639,14 @@ user_pref("alerts.showFavicons", false); // [DEFAULT: false]
 ***/
 user_pref("_user.js.parrot", "1200 syntax error: the parrot's a stiff!");
 /** SSL (Secure Sockets Layer) / TLS (Transport Layer Security) ***/
-/* 1201: disable old SSL/TLS "insecure" renegotiation (vulnerable to a MiTM attack)
- * [SETUP-WEB] <2% of secure sites do NOT support the newer "secure" renegotiation, see [2]
- * [1] https://wiki.mozilla.org/Security:Renegotiation
- * [2] https://www.ssllabs.com/ssl-pulse/ ***/
+/* 1201: disable old SSL/TLS "insecure" negotiation (vulnerable to a MiTM attack)
+ * [1] https://wiki.mozilla.org/Security:Renegotiation ***/
 user_pref("security.ssl.require_safe_negotiation", true);
 /* 1202: control TLS versions with min and max
  * 1=TLS 1.0, 2=TLS 1.1, 3=TLS 1.2, 4=TLS 1.3
  * [WARNING] Leave these at default, otherwise you alter your TLS fingerprint.
- * Firefox telemetry (April 2019) shows only 0.5% of TLS web traffic uses 1.0 or 1.1 ***/
+ * Firefox telemetry (April 2019) shows only 0.5% of TLS web traffic uses 1.0 or 1.1
+ * [1] https://www.ssllabs.com/ssl-pulse/ ***/
    // user_pref("security.tls.version.min", 3);
    // user_pref("security.tls.version.max", 4);
 /* 1203: disable SSL session tracking [FF36+]


### PR DESCRIPTION
https://wiki.mozilla.org/Security:Renegotiation describes

> **the new default behaviour** that was introduced in experimental mozilla-central nightly versions on 2010-02-08

where the last step is

> - should the server (or a MITM) request **renegotiation**, Mozilla will terminate the connection with an error message

and then after talking about breakage ...

> The above defaults may break some client/server environments where a Server is still using old software and requires renegotiation.

mentions workarounds to reduce said breakage:

> In order to give such environments a way to keep using Firefox (et.al.) to connect to their vulnerable server infrastructure, the following preferences are available:

specifically talking about the first 2 prefs listed there, one allowing to specify a list of hosts "where renegotiation may be performed" and the 2nd one "completely disables the new protection mechanisms".
But both those prefs were removed in FF38, meaning that since then it's no longer possible to disable the default behaviour that is "should the server (or a MITM) request **renegotiation**, Mozilla will terminate the connection with an error message".

But all of this is about the **re**-negotiation part and not negotiation. And nowhere does it say "insecure" renegotiation, which, as I read it, means that FF will terminate the connection for any kind of **renegotiation**, safe or unsafe.

1201 controls the negotiation part:

> This pref controls the behaviour during the initial negotiation between client and server.
>
> If set to true, a Mozilla client will reject all connection attempts to servers that are still using the old SSL/TLS protocol and which might be vulnerable to the attack.
>
> Setting this preference to “true” is the only way to guarantee full protection against the attack.

I think "servers that are still using the old SSL/TLS protocol" actually means servers that **only** support the old protocols.
Servers still supporting those old protocols in addition to some new protocol versions should not be affected by this pref because FF will be able to negotiate to use one of the newer protocol versions.

Ergo lets fix the title and remove the line about renegotiation support because I think that's irrelevant.


ps. the sslpulse link is nice and I'd like to keep it somewhere but it doesn't really fit in 1201 IMO so I moved it to 1202.