### PR TITLE
Media Cache Section

### DIFF
--- a/user.js
+++ b/user.js
@@ -583,17 +583,28 @@ user_pref("_user.js.parrot", "1000 syntax error: the parrot's gone to meet 'is m
  * [NOTE] We also clear cache on exiting Firefox (see 2803) ***/
 user_pref("browser.cache.disk.enable", false);
 /* 1003: disable memory cache
-/* capacity: -1=determine dynamically (default), 0=none, n=memory capacity in kilobytes ***/
+/* capacity: -1=determine dynamically (default), 0=none, n=memory capacity in kibibytes ***/
    // user_pref("browser.cache.memory.enable", false);
    // user_pref("browser.cache.memory.capacity", 0); // [HIDDEN PREF ESR]
 /* 1006: disable permissions manager from writing to disk [RESTART]
  * [NOTE] This means any permission changes are session only
  * [1] https://bugzilla.mozilla.org/967812 ***/
    // user_pref("permissions.memory_only", true); // [HIDDEN PREF]
-/* 1007: disable media cache from writing to disk in Private Browsing
- * [NOTE] MSE (Media Source Extensions) are already stored in-memory in PB */
+/** MEDIA CACHE 
+ * Media cache is separate from the main cache. It it used for HTML5-style media objects such
+ * as <video> and only keeps them in cache while they are open. It is primarily a disk-based
+ * cache, however media objects will be stored in memory instead if certain conditions are met. ***/
+/* 1010: a media object will be stored in memory instead of disk if its size is less than all three of: */
+user_pref("media.memory_cache_max_size", 81920); // (in KiB) [DEFAULT: 8,192]
+   // user_pref("media.memory_caches_combined_limit_kb", 524288); // (in KiB) [DEFAULT: 524,288]
+   // user_pref("media.memory_caches_combined_limit_pc_sysmem", 5); // (in % of system memory) [DEFAULT: 5]
+/* 1014: max size of media disk cache in KiB
+ * [NOTE] Setting to 0 does not disable. A small disk cache will still be used and playback will be impaired ***/
+   // user_pref("media.cache_size", 512000); // [DEFAULT: 512,000]
+/* 1016: Prevent media cache from writing to disk in Private Browsing. Memory cache will be used even if
+ * the whole object doesn't fit. Memory cache used by a single object will be limited by 1010.
+ * [NOTE] MSE (Media Source Extensions) are already stored in-memory in PB ***/
 user_pref("browser.privatebrowsing.forceMediaMemoryCache", true); // [FF75+]
-user_pref("media.memory_cache_max_size", 16384);
 
 /** SESSIONS & SESSION RESTORE ***/
 /* 1020: exclude "Undo Closed Tabs" in Session Restore ***/


### PR DESCRIPTION
Hello. I've been using your excellent user.js to customize my Firefox, and I'm pleased to finally offer back a contribution. I tested lots of variations on these settings in different situations, plus looked into the source code, to arrive at these findings. I used large video files because it's easy to observe what FF does with a large chunk of data.

The media cache is separate from the main cache. It it used instead of the main cache for HTML5-style media objects such as `<video>`, and only keeps them in cache while the objects are open (i.e. navigating away to another page or closing the tab removes the objects from cache.) The media cache is primarily a disk-based cache, having been originally coded that way, however a memory-based media cache was added later and will be used instead if certain conditions are met. Only one cache type is used per media object.

A media object will be stored in memory instead of disk if the size of the media object is lower than all three of:
`media.memory_cache_max_size` (in KiB; default 8,192)
`media.memory_caches_combined_limit_kb` (in KiB, default 524,288)
`media.memory_caches_combined_limit_pc_sysmem` (in percent of system memory; default 5)

The two combined_limit prefs appear to be intended to limit the combined size of all the media objects in memory cache, but they don't do that.

If memory cache is not used, disk cache is used instead. The size of the disk cache is controlled by:
`media.cache_size` (in KiB; default 512,000)
The disk cache can't be disabled by setting this to 0. In that case, FF still uses a disk cache, but it is small (~12 MB) and playback may be impacted as a result.

While in private browsing mode, and while `browser.privatebrowsing.forceMediaMemoryCache` is set to true, disk cache is never used. In this case, the memory cache is used even if the media object is larger than `media.memory_cache_max_size`. The available memory cache is used, with parts of the object evicted as needed to stay within the limit (of a single object; combined memory cache size is still not limited). The default memory cache limit of 8 MiB is not adequate for high bitrate videos; playback will be impacted because the buffer is too small. If the media object is larger than either of the combined_limit prefs, it will not load at all.

I decided to set my limits to 3 GiB, 3 GiB and 50% because I want FF to use memory instead of disk whenever possible, and I have plenty of RAM. That's why I included the two combined_limit prefs -- they also need to be increased if a user wants to be able to use memory for large media objects.

Some large videos I used for testing (note: navigating directly to the videos, or accessing them as <video> objects on a webpage, seemed to produce the same results in all cases):
[530 MB] [https://upload.wikimedia.org/wikipedia/commons/f/fa/Mru_women_performing_the_Chiasotpoi_dance.webm](https://upload.wikimedia.org/wikipedia/commons/f/fa/Mru_women_performing_the_Chiasotpoi_dance.webm)
[506 MB] [https://upload.wikimedia.org/wikipedia/commons/7/70/Schwan_aus_n%C3%A4chster_N%C3%A4he_2160p30_HDR_20200405.webm](https://upload.wikimedia.org/wikipedia/commons/7/70/Schwan_aus_n%C3%A4chster_N%C3%A4he_2160p30_HDR_20200405.webm)
[478 MB] [https://upload.wikimedia.org/wikipedia/commons/a/a1/BIOASTRONAUTICS_RESEARCH_Gov.archives.arc.68700.ogv](https://upload.wikimedia.org/wikipedia/commons/a/a1/BIOASTRONAUTICS_RESEARCH_Gov.archives.arc.68700.ogv)