### PR TITLE
various, #959

### DIFF
--- a/user.js
+++ b/user.js
@@ -125,6 +125,9 @@ user_pref("browser.newtabpage.activity-stream.showSponsored", false);
 user_pref("browser.newtabpage.activity-stream.feeds.discoverystreamfeed", false); // [FF66+]
 /* 0105d: disable Activity Stream recent Highlights in the Library [FF57+] ***/
    // user_pref("browser.library.activity-stream.enabled", false);
+/* 0105e: clear default topsites
+ * [NOTE] This does not block you from adding your own */
+user_pref("browser.newtabpage.activity-stream.default.sites", false);
 /* 0110: start Firefox in PB (Private Browsing) mode
  * [NOTE] In this mode *all* windows are "private windows" and the PB mode icon is not displayed
  * [WARNING] The P in PB mode is misleading: it means no "persistent" disk storage such as history,
@@ -175,7 +178,7 @@ user_pref("javascript.use_us_english_locale", true); // [HIDDEN PREF]
 /* 0212: enforce fallback text encoding to match en-US
  * When the content or server doesn't declare a charset the browser will
  * fallback to the "Current locale" based on your application language
- * [SETTING] General>Language and Appearance>Fonts and Colors>Advanced>Text Encoding for Legacy Content
+ * [SETTING] General>Language and Appearance>Fonts and Colors>Advanced>Text Encoding for Legacy Content (FF72-)
  * [TEST] https://hsivonen.com/test/moz/check-charset.htm
  * [1] https://gitlab.torproject.org/tpo/applications/tor-browser/-/issues/20025 ***/
 user_pref("intl.charset.fallback.override", "windows-1252");
@@ -205,7 +208,7 @@ user_pref("app.update.auto", false);
    // user_pref("extensions.getAddons.cache.enabled", false);
 /* 0308: disable search engine updates (e.g. OpenSearch)
  * [NOTE] This does not affect Mozilla's built-in or Web Extension search engines
- * [SETTING] General>Firefox Updates>Automatically update search engines ***/
+ * [SETTING] General>Firefox Updates>Automatically update search engines (FF72-) ***/
 user_pref("browser.search.update", false);
 /* 0309: disable sending Flash crash reports ***/
 user_pref("dom.ipc.plugins.flash.subprocess.crashreporter.enabled", false);
@@ -1502,6 +1505,9 @@ user_pref("privacy.resistFingerprinting.letterboxing", true); // [HIDDEN PREF]
  * When default true (FF62+) this no longer masks the RFP chrome resizing activity
  * [1] https://bugzilla.mozilla.org/1448423 ***/
 user_pref("browser.startup.blankWindow", false);
+/* 4520: disable chrome animations [FF77+] [RESTART]
+ * [NOTE] pref added in FF63, but applied to chrome in FF77. RFP spoofs this for web content ***/
+user_pref("ui.prefersReducedMotion", 1); // [HIDDEN PREF]
 
 /*** [SECTION 4600]: RFP ALTERNATIVES
    * non-RFP users:
@@ -1757,7 +1763,7 @@ user_pref("browser.tabs.remote.allowLinkedWebInFileUriProcess", false);
 // 2031: disable autoplay of HTML5 media if you interacted with the site [FF66+] - replaced by 'media.autoplay.blocking_policy'
    // [-] https://bugzilla.mozilla.org/1509933
 user_pref("media.autoplay.enabled.user-gestures-needed", false);
-// 5000's: disable chrome animations - replaced FF77+ by 'ui.prefersReducedMotion' (4617)
+// 5000's: disable chrome animations - replaced FF77+ by 'ui.prefersReducedMotion' (4520)
    // [-] https://bugzilla.mozilla.org/1640501
    // user_pref("toolkit.cosmeticAnimations.enabled", false); // [FF55+]
 // * * * /

--- a/user.js
+++ b/user.js
@@ -126,7 +126,7 @@ user_pref("browser.newtabpage.activity-stream.feeds.discoverystreamfeed", false)
 /* 0105d: disable Activity Stream recent Highlights in the Library [FF57+] ***/
    // user_pref("browser.library.activity-stream.enabled", false);
 /* 0105e: clear default topsites
- * [NOTE] This does not block you from adding your own */
+ * [NOTE] This does not block you from adding your own ***/
 user_pref("browser.newtabpage.activity-stream.default.sites", false);
 /* 0110: start Firefox in PB (Private Browsing) mode
  * [NOTE] In this mode *all* windows are "private windows" and the PB mode icon is not displayed

--- a/user.js
+++ b/user.js
@@ -127,7 +127,7 @@ user_pref("browser.newtabpage.activity-stream.feeds.discoverystreamfeed", false)
    // user_pref("browser.library.activity-stream.enabled", false);
 /* 0105e: clear default topsites
  * [NOTE] This does not block you from adding your own ***/
-user_pref("browser.newtabpage.activity-stream.default.sites", false);
+user_pref("browser.newtabpage.activity-stream.default.sites", "");
 /* 0110: start Firefox in PB (Private Browsing) mode
  * [NOTE] In this mode *all* windows are "private windows" and the PB mode icon is not displayed
  * [WARNING] The P in PB mode is misleading: it means no "persistent" disk storage such as history,


### PR DESCRIPTION
- `0105e`
   - we disable AS, and clearing the default does not stop someone adding their own (it's a different pref) should they chose to use AS
   - otherwise, to get rid of the topsites when clicking in an empty urlbar, users have to either know about this pref or enable AS and go manually remove them all
   - this is cleaner than disabling topsites with `browser.newtabpage.activity-stream.default.sites` as that actually breaks the functionality (should users want to use AS and topsite suggestions)
   - we don't disable topsite suggestions: 0850a: 78+, `browser.urlbar.suggest.topsites` is inactive
   - this is the list you see when you click in an empty urlbar, and obviously if you have no topsites then the 0850a pref is rendered useless for suggestions as you type, but doesn't break the functionality if a user does add their own topsites
   - capisce? easy peasy? clear as mud?
- 0850a
   - we could elaborate that this is for suggestions when you start typing/pasting (i.e not the same as topsites) - IDK
- settings (changed)
   - we can remove these two when ESR68 hits EOL, meanwhile I just tagged them as (FF72-)
- settings (not changed)
   - `0517` does not seem to exist: [SETTING] Privacy & Security>Forms and Autofill>Autofill addresses (FF74+)
   - I tested vanilla profiles in 74+, and system addon `formautofill@mozilla.org.xpi` is present
   - maybe I'm doing something wrong
- `0420`: ui.PRM
   - maybe you can word it better