### PR TITLE
dnsResolveSingleWordsAfterSearch

### DIFF
--- a/user.js
+++ b/user.js
@@ -461,9 +461,8 @@ user_pref("_user.js.parrot", "0800 syntax error: the parrot's ceased to be!");
 /* 0801: disable location bar using search
  * Don't leak URL typos to a search engine, give an error message instead.
  * Examples: "secretplace,com", "secretplace/com", "secretplace com", "secret place.com"
- * [NOTE] Search buttons in the dropdown work, but hitting 'enter' in the location bar will fail
- * [TIP] You can add keywords to search engines in options (e.g. 'd' for DuckDuckGo) and
- * the dropdown will now auto-select it and you can then hit 'enter' and it will work
+ * [NOTE] This does **not** affect explicit user action such as using search buttons in the
+ * dropdown, or using keyword search shortcuts you configure in options (e.g. 'd' for DuckDuckGo)
  * [SETUP-CHROME] If you don't, or rarely, type URLs, or you use a default search
  * engine that respects privacy, then you probably don't need this ***/
 user_pref("keyword.enabled", false);
@@ -497,6 +496,11 @@ user_pref("browser.urlbar.usepreloadedtopurls.enabled", false);
 /* 0810: disable location bar making speculative connections [FF56+]
  * [1] https://bugzilla.mozilla.org/1348275 ***/
 user_pref("browser.urlbar.speculativeConnect.enabled", false);
+/* 0811: disable location bar leaking single words to DNS provider **after searching** [FF78+]
+ * 0=never resolve single words, 1=heuristic (default), 2=always resolve
+ * For FF78 value 1 and 2 are the same and always resolve but that will change in future versions
+ * [1] https://bugzilla.mozilla.org/1642623 ***/
+user_pref("browser.urlbar.dnsResolveSingleWordsAfterSearch", 0);
 /* 0850a: disable location bar suggestion types
  * [SETTING] Privacy & Security>Address Bar>When using the address bar, suggest ***/
    // user_pref("browser.urlbar.suggest.history", false);

--- a/user.js
+++ b/user.js
@@ -496,9 +496,9 @@ user_pref("browser.urlbar.usepreloadedtopurls.enabled", false);
 /* 0810: disable location bar making speculative connections [FF56+]
  * [1] https://bugzilla.mozilla.org/1348275 ***/
 user_pref("browser.urlbar.speculativeConnect.enabled", false);
-/* 0811: disable location bar leaking single words to DNS provider **after searching** [FF78+]
+/* 0811: disable location bar leaking single words to a DNS provider **after searching** [FF78+]
  * 0=never resolve single words, 1=heuristic (default), 2=always resolve
- * For FF78 value 1 and 2 are the same and always resolve but that will change in future versions
+ * [NOTE] For FF78 value 1 and 2 are the same and always resolve but that will change in future versions
  * [1] https://bugzilla.mozilla.org/1642623 ***/
 user_pref("browser.urlbar.dnsResolveSingleWordsAfterSearch", 0);
 /* 0850a: disable location bar suggestion types


### PR DESCRIPTION
I almost feel as if everyone (myself included) forgot the pref name .. **AfterSearch** and we don't even need to ~~add a note at all~~ mention 0801 at all: it's not about `keyword.enabled` .. it's about searching