### PR TITLE
0207/0208: region/search

### DIFF
--- a/user.js
+++ b/user.js
@@ -165,6 +165,13 @@ user_pref("geo.provider.use_gpsd", false); // [LINUX]
  * i.e. ignore all of Mozilla's various search engines in multiple locales ***/
 user_pref("browser.search.geoSpecificDefaults", false);
 user_pref("browser.search.geoSpecificDefaults.url", "");
+/* 0207: disable region updates
+ * [1] https://firefox-source-docs.mozilla.org/toolkit/modules/toolkit_modules/Region.html ***/
+user_pref("browser.region.update.enabled", false);
+user_pref("browser.region.network.url", ""); // [FF78+]
+/* 0208: set search region
+ * [NOTE] May not be hidden if Firefox has changed your settings due to your region (see 0207) ***/
+   // user_pref("browser.search.region", "US"); // [HIDDEN PREF]
 
 /** LANGUAGE / LOCALE ***/
 /* 0210: set preferred language for displaying web pages

--- a/user.js
+++ b/user.js
@@ -167,8 +167,8 @@ user_pref("browser.search.geoSpecificDefaults", false);
 user_pref("browser.search.geoSpecificDefaults.url", "");
 /* 0207: disable region updates
  * [1] https://firefox-source-docs.mozilla.org/toolkit/modules/toolkit_modules/Region.html ***/
-user_pref("browser.region.update.enabled", false);
 user_pref("browser.region.network.url", ""); // [FF78+]
+user_pref("browser.region.update.enabled", false); // [[FF79+]
 /* 0208: set search region
  * [NOTE] May not be hidden if Firefox has changed your settings due to your region (see 0207) ***/
    // user_pref("browser.search.region", "US"); // [HIDDEN PREF]


### PR DESCRIPTION
- I split it into two: because regions cover more than just search (and can get future feature creep) - the link says "search and content"
- I don't want to make the search region active, because that might create problems for non en-US users .. or indeed, for any users not in en-US region
- I do not know how this affects new profiles: does the region ever get set? in en-US I **think** it's the default, but what about others (how quick is it set after a new profile is created?)
- does `browser.region.update.enabled` need a version number?  I don't think we need bother with a hidden tag since it's no longer hidden in 80, but I don't know when it was added and when it was made functional: maybe it's best to just tag it as `[FF80+]`
- if we do that we should change the `0207` order to alphabetical as that would also match when the pref was made useful
- I included the URL pref as defense in depth and TB set it blank as well