### PR TITLE
Updater.sh rework 2

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -238,7 +238,7 @@ add_override () {
     do
       add_override "$f"
     done
-    IFS=$SAVEIFS # restore $IFS
+    IFS=$FSAVEIFS # restore $IFS
   else
     echo -e "${ORANGE}Warning: Could not find override file:${NC} ${input}"
   fi

--- a/updater.sh
+++ b/updater.sh
@@ -325,7 +325,6 @@ update_userjs () {
 #########################
 
 if [ $# != 0 ]; then
-  readonly legacy_lc=$(echo $1 | tr '[A-Z]' '[a-z]')
   # Display usage if first argument is -help or --help
   if [ $1 = '--help' ] || [ $1 = '-help' ]; then
     usage

--- a/updater.sh
+++ b/updater.sh
@@ -107,7 +107,7 @@ Optional Arguments:
 download_file () {   # expects URL as argument ($1)
   declare -r tf=$(mktemp)
 
-  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || exit 1 # return the temp-filename (or empty string on error)
+  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || exit 1 # return the temp-filename or exit on error
 }
 
 open_file () { #expects one argument: file_path

--- a/updater.sh
+++ b/updater.sh
@@ -107,7 +107,7 @@ Optional Arguments:
 download_file () {   # expects URL as argument ($1)
   declare -r tf=$(mktemp)
 
-  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || exit 1 # return the temp-filename or exit on error
+  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || return 1 # return the temp-filename or return error code 1
 }
 
 open_file () { #expects one argument: file_path
@@ -249,7 +249,8 @@ remove_comments () { # expects 2 arguments: from-file and to-file
 
 # Applies latest version of user.js and any custom overrides
 update_userjs () {
-  declare -r newfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')
+  declare -r newfile="$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')" ret="$?"
+  [ "$ret" -ne 0 ] && echo -e "${RED}Error! Could not download user.js${NC}" && return 1
 
   echo -e "Please observe the following information:
     Firefox profile:  ${ORANGE}$(pwd)${NC}

--- a/updater.sh
+++ b/updater.sh
@@ -231,14 +231,14 @@ add_override () {
     cat "$input" >> user.js
     echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
   elif [ -d "$input" ]; then
-    FSAVEIFS=$IFS
+    SAVEIFS=$IFS
     IFS=$'\n\b' # Set IFS
     FILES="${input}"/*.js
     for f in $FILES
     do
       add_override "$f"
     done
-    IFS=$FSAVEIFS # restore $IFS
+    IFS=$SAVEIFS # restore $IFS
   else
     echo -e "${ORANGE}Warning: Could not find override file:${NC} ${input}"
   fi

--- a/updater.sh
+++ b/updater.sh
@@ -107,7 +107,7 @@ Optional Arguments:
 download_file () {   # expects URL as argument ($1)
   declare -r tf=$(mktemp)
 
-  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || return 1 # return the temp-filename or return error code 1
+  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || echo '' # return the temp-filename or empty string on error
 }
 
 open_file () { #expects one argument: file_path
@@ -196,6 +196,7 @@ update_updater () {
   fi
 
   declare -r tmpfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh')
+  [ -z "${tmpfile}" ] && echo -e "${RED}Error! Could not download updater.sh${NC}" && return 1 # check if download failed
 
   if [[ $(get_updater_version "${SCRIPT_DIR}/updater.sh") < $(get_updater_version "${tmpfile}") ]]; then
     if [ $UPDATE = 'check' ]; then
@@ -249,8 +250,8 @@ remove_comments () { # expects 2 arguments: from-file and to-file
 
 # Applies latest version of user.js and any custom overrides
 update_userjs () {
-  declare -r newfile="$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')" ret="$?"
-  [ "$ret" -ne 0 ] && echo -e "${RED}Error! Could not download user.js${NC}" && return 1
+  declare -r newfile="$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')"
+  [ -z "${newfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && return 1 # check if download failed
 
   echo -e "Please observe the following information:
     Firefox profile:  ${ORANGE}$(pwd)${NC}
@@ -370,6 +371,7 @@ if [ $# != 0 ]; then
           ;;
         r)
           tfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')
+          [ -z "${tfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && exit 1 # check if download failed
           mv $tfile "${tfile}.js"
           echo -e "${ORANGE}Warning: user.js was saved to temporary file ${tfile}.js${NC}"
           open_file "${tfile}.js"

--- a/updater.sh
+++ b/updater.sh
@@ -124,7 +124,7 @@ readIniFile () { # expects one argument: absolute path of profiles.ini
   declare -r inifile="$1"
 
   # tempIni will contain: [ProfileX], Name=, IsRelative= and Path= of the only (if) or the selected (else) profile
-  if [ $(grep -c '^\[Profile' "${inifile}") == "1" ]; then ### only 1 profile found
+  if [ "$(grep -c '^\[Profile' "${inifile}")" == "1" ]; then ### only 1 profile found
     tempIni="$(grep '^\[Profile' -A 4 "${inifile}")"
   else
     echo 'Profiles found:'
@@ -143,7 +143,7 @@ readIniFile () { # expects one argument: absolute path of profiles.ini
   # extracting only the path itself, excluding "Path="
   PROFILE_PATH=$(echo "${tempIni}" | sed -n 's/^Path=\(.*\)$/\1/p')
   # update global variable if path is relative
-  [[ ${pathisrel} == "1" ]] && PROFILE_PATH="$(dirname "${inifile}")/${profpath}"
+  [[ ${pathisrel} == "1" ]] && PROFILE_PATH="$(dirname "${inifile}")/${PROFILE_PATH}"
 }
 
 getProfilePath () {

--- a/updater.sh
+++ b/updater.sh
@@ -195,7 +195,7 @@ update_updater () {
     return 0 # User signified not to check for updates
   fi
 
-  declare -r tmpfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh')
+  declare -r tmpfile="$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/updater.sh')"
   [ -z "${tmpfile}" ] && echo -e "${RED}Error! Could not download updater.sh${NC}" && return 1 # check if download failed
 
   if [[ $(get_updater_version "${SCRIPT_DIR}/updater.sh") < $(get_updater_version "${tmpfile}") ]]; then
@@ -370,7 +370,7 @@ if [ $# != 0 ]; then
           ESR=true
           ;;
         r)
-          tfile=$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')
+          tfile="$(download_file 'https://raw.githubusercontent.com/ghacksuserjs/ghacks-user.js/master/user.js')"
           [ -z "${tfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && exit 1 # check if download failed
           mv $tfile "${tfile}.js"
           echo -e "${ORANGE}Warning: user.js was saved to temporary file ${tfile}.js${NC}"

--- a/updater.sh
+++ b/updater.sh
@@ -2,7 +2,7 @@
 
 ## ghacks-user.js updater for macOS and Linux
 
-## version: 2.6
+## version: 2.7
 ## Author: Pat Johnson (@overdodactyl)
 ## Additional contributors: @earthlng, @ema-pe, @claustromaniac
 


### PR DESCRIPTION
### `#2`
##### DOWNLOAD_METHOD
* merge two declarations of download command into one
* add max-redirects to prevent redirect loops
* add silent options (prettier than `> /dev/null`)
##### download_file()
* shorten `download_file ()`
* exit instead of continue with a "non-file", which can lead to unwanted behavior
##### open_file()
* open_file(): pipe instead of nested sub-shell
##### readIniFile()
* readIniFile(): `grep -c` equals `grep | wc -l`
* make output prettier
* work with variable instead of temporary file
* update `PROFILE_PATH` more directly