### PR TITLE
Fail curl request on HTTP error status

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -23,7 +23,7 @@ QUICKSTART=false
 ## download method priority: curl -> wget
 DOWNLOAD_METHOD=''
 if command -v curl >/dev/null; then
-	DOWNLOAD_METHOD='curl --max-redirs 3 -so'
+	DOWNLOAD_METHOD='curl --max-redirs 3 -fso'
 elif command -v wget >/dev/null; then
 	DOWNLOAD_METHOD='wget --max-redirect 3 --quiet -O'
 else

--- a/updater.sh
+++ b/updater.sh
@@ -48,7 +48,7 @@ ESR=false
 # Download method priority: curl -> wget
 DOWNLOAD_METHOD=''
 if command -v curl >/dev/null; then
-  DOWNLOAD_METHOD='curl --max-redirs 3 -so'
+  DOWNLOAD_METHOD='curl --max-redirs 3 -fso'
 elif command -v wget >/dev/null; then
   DOWNLOAD_METHOD='wget --max-redirect 3 --quiet -O'
 else


### PR DESCRIPTION
Use the `-f' option to instruct curl to exit with a non-zero exit code if the HTTP response indicates an error via its status code.  This is the default behavior for wget, but curl will send the request and exit normally (with exit code equals to zero), as long as it's received a response from the server.

Note that this issue is already fixed by #1908.  The only change this pull request does is change two lines to add the `-f' option to curl.  I figured that since GitHub is blocking users that are logged off from downloading repository files[^1], this would be useful since my user.js file is being updated incorrectly, and GitHub's error message is being erroneously written to that file.

[^1]: https://github.com/orgs/community/discussions/159123