### PR TITLE
fix clearing browsing history on shutdown

### DIFF
--- a/user.js
+++ b/user.js
@@ -634,6 +634,7 @@ user_pref("_user.js.parrot", "2800 syntax error: the parrot's bleedin' demised!"
  * via history (2830), will no longer remove sanitize on shutdown "cookie and site data" site exceptions (2815)
  * [SETTING] Privacy & Security>History>Custom Settings>Clear history when Firefox closes | Settings ***/
 user_pref("privacy.sanitize.sanitizeOnShutdown", true);
+user_pref("privacy.sanitize.clearOnShutdown.hasMigratedToNewPrefs3", true);
 
 /** SANITIZE ON SHUTDOWN: IGNORES "ALLOW" SITE EXCEPTIONS ***/
 /* 2811: set/enforce clearOnShutdown items (if 2810 is true) [SETUP-CHROME] [FF128+] ***/


### PR DESCRIPTION
**What**:

This user.js clears some data on exit, but is not intending to clear browsing history on exit. I am referring to these lines in the user.js:

```
user_pref("privacy.clearOnShutdown_v2.historyFormDataAndDownloads", false); // [DEFAULT: true]
user_pref("privacy.clearOnShutdown_v2.browsingHistoryAndDownloads", false); // [DEFAULT: true]
```

However, for some reason, the actual behavior is that the browsing history is deleted on shutdown.

**How to reproduce**:

0. Backup your Firefox profile because you are going to loose your browsing history
1. Copy the user.js version 140.1 (no modifications) to your Firefox profile
2. `rm prefs.js`
3. Start Firefox (I am using 146.0.1)
4. Visit any website
5. Close Firefox
6. Restart Firefox
7. Observe that the browsing history is empty (the website you just visited does not show up in the browsing history)

**The fix**:

Here is how I found the fix:

1. `rm prefs.js`
2. Start Firefox
3. `cp prefs.js prefs.js.tmp`
4. Go to Settings > History > "Clear history when Firefox closes" > Settings
5. See that "Browsing & download history" is checked, even though it should be unchecked according to how this user.js configures Firefox
      <img width="300" src="https://github.com/user-attachments/assets/b0571311-7966-48d1-9cb8-d70f39400a33" />
6. Check and again uncheck the checkbox and then save the changes
7. `diff prefs.js prefs.js.tmp`

Observe that Firefox added the line

```
user_pref("privacy.sanitize.clearOnShutdown.hasMigratedToNewPrefs3", true);
```

among others.

After I added this line to my user.js, I deleted prefs.js again and now the "Browsing & download history" checkbox is unchecked as expected and the browsing history is not deleted anymore.

I dont know, but maybe not everybody runs into this problem, because maybe

```
user_pref("privacy.sanitize.clearOnShutdown.hasMigratedToNewPrefs3", true);
```

is set in the prefs.js for most people?